### PR TITLE
🔀 :: (#91) - 예약 화면 배치도 보기 지도 아이콘 수정

### DIFF
--- a/lib/features/reservation/presentation/widgets/reservation_section_widget.dart
+++ b/lib/features/reservation/presentation/widgets/reservation_section_widget.dart
@@ -6,6 +6,7 @@ import 'package:washer/core/enums/laundry_status.dart';
 import 'package:washer/core/enums/reservation_state.dart';
 import 'package:washer/core/router/route_paths.dart';
 import 'package:washer/core/theme/color.dart';
+import 'package:washer/core/theme/icon.dart';
 import 'package:washer/core/theme/spacing.dart';
 import 'package:washer/core/theme/typography.dart';
 import 'package:washer/features/home/presentation/viewmodels/home_view_model.dart';
@@ -260,6 +261,11 @@ class _FloorSelectorRow extends StatelessWidget {
                 style: WasherTypography.body4(WasherColor.baseGray300),
               ),
               AppGap.h4,
+              const WasherIcon(
+                type: WasherIconType.map,
+                size: 20,
+                color: WasherColor.baseGray300,
+              ),
             ],
           ),
         ),


### PR DESCRIPTION
## 💡 개요
예약 화면의 `배치도 보기` 우측 지도 아이콘이 실제 기기에서 보이지 않던 문제를 수정했습니다.

## 🔗 관련 이슈
Closes #91

## 📃 작업내용
- `reservation_section_widget.dart`에 아이콘 테마 import를 추가했습니다.
- `배치도 보기` 우측에 `WasherIconType.map` 아이콘 렌더링을 추가했습니다.
- 에셋 누락이 아닌 UI 위젯 누락이 원인임을 확인하고 최소 범위로 수정했습니다.

## 🔍 테스트 방법
- `fvm flutter analyze lib\features\reservation\presentation\widgets\reservation_section_widget.dart` 실행
- 예약 화면에서 `배치도 보기` 텍스트 오른쪽에 지도 아이콘이 노출되는지 확인

## 🖼️ 스크린샷

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [x] 불필요한 코드가 없는지 확인했습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 기존 기능이 정상적으로 작동하는지 확인했습니다.
