### PR TITLE
🔀 :: (#97) - 앱바 하단 공통 간격 및 아이콘 크기 조정

### DIFF
--- a/lib/core/ui/base_scaffold.dart
+++ b/lib/core/ui/base_scaffold.dart
@@ -26,13 +26,10 @@ class BaseScaffold extends StatelessWidget {
           : null,
       body: SafeArea(
         child: Padding(
-          padding: AppPadding.screenHPadding,
-          child: Padding(
-            padding: EdgeInsets.only(
-              top: showAppBar ? AppSpacing.v12 : 0,
-            ),
-            child: body,
+          padding: AppPadding.screenHPadding.copyWith(
+            top: showAppBar ? AppSpacing.v12 : 0,
           ),
+          child: body,
         ),
       ),
       bottomNavigationBar: bottomNavigationBar,


### PR DESCRIPTION
## 💡 개요
앱바가 있는 화면의 본문 상단 간격을 공통으로 조정하고, 아이콘 크기에 ScreenUtil을 적용했습니다.

## 🔗 관련 이슈
Closes #97

## 📃 작업내용
- `BaseScaffold`에서 앱바가 있는 화면에만 본문 상단 여백이 공통 적용되도록 수정했습니다.
- `WasherIcon` 공통 컴포넌트에 ScreenUtil을 적용해 아이콘 크기가 화면 비율에 맞게 반영되도록 조정했습니다.
- 아이콘 버튼의 터치 영역 반경도 ScreenUtil 기준에 맞춰 함께 보정했습니다.

## 🔍 테스트 방법
- `fvm flutter analyze lib\core\theme\icon.dart lib\core\ui\base_scaffold.dart lib\core\ui\main_shell.dart lib\core\ui\washer_appbar.dart lib\features\reservation\presentation\widgets\reservation_section_widget.dart` 실행
- 홈, 예약, 알람 화면에서 앱바 아래 간격이 기존보다 약 12만큼 추가되었는지 확인
- 예약 화면에서 `배치도 보기` 오른쪽 아이콘 크기가 화면 비율에 맞게 보이는지 확인

## 🖼️ 스크린샷

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [x] 불필요한 코드가 없는지 확인했습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 기존 기능이 정상적으로 작동하는지 확인했습니다.
