### PR TITLE
🔀 :: (#128) - 예약 흐름과 인증 만료 처리 개선

### DIFF
--- a/lib/core/constants/durations.dart
+++ b/lib/core/constants/durations.dart
@@ -1,0 +1,4 @@
+const int reservationExpiryMinutes = 3;
+const Duration reservationExpiryDuration = Duration(
+  minutes: reservationExpiryMinutes,
+);

--- a/lib/core/enums/laundry_status.dart
+++ b/lib/core/enums/laundry_status.dart
@@ -4,7 +4,6 @@ import '../theme/color.dart';
 
 enum LaundryStatus {
   reserved, // 예약완료
-  confirmed, // 예약확인 및 기기 동작 감지
   needConfirm, // 확인필요
   inUse, // 사용중
   completed, // 완료
@@ -15,8 +14,6 @@ extension LaundryStatusExt on LaundryStatus {
     switch (this) {
       case LaundryStatus.reserved:
         return "대기중";
-      case LaundryStatus.confirmed:
-        return "예약완료";
       case LaundryStatus.needConfirm:
         return "확인필요";
       case LaundryStatus.inUse:
@@ -33,8 +30,6 @@ extension LaundryStatusExt on LaundryStatus {
       case LaundryStatus.reserved:
         return WasherColor.mainColor300;
       case LaundryStatus.inUse:
-        return WasherColor.mainColor400;
-      case LaundryStatus.confirmed:
         return WasherColor.mainColor400;
       case LaundryStatus.completed:
         return WasherColor.mainColor400;

--- a/lib/core/enums/reservation_state.dart
+++ b/lib/core/enums/reservation_state.dart
@@ -7,7 +7,6 @@ enum ReservationState {
   available, // 예약가능
   reservedByMe, // 예약완료 (본인)
   reservedByOther, // 예약완료 (타인)
-  confirmed, // 예약확인중 (본인)
   unavailable, // 사용불가
 }
 
@@ -22,8 +21,6 @@ extension ReservationStateText on ReservationState {
         return '예약완료';
       case ReservationState.reservedByOther:
         return '예약완료';
-      case ReservationState.confirmed:
-        return '예약확인중';
       case ReservationState.unavailable:
         return '사용불가';
     }
@@ -36,7 +33,6 @@ extension ReservationStateText on ReservationState {
       case ReservationState.inUse:
       case ReservationState.reservedByMe:
       case ReservationState.reservedByOther:
-      case ReservationState.confirmed:
         return WasherColor.mainColor400;
       case ReservationState.unavailable:
         return WasherColor.errorColor;

--- a/lib/core/network/auth_interceptor.dart
+++ b/lib/core/network/auth_interceptor.dart
@@ -57,8 +57,10 @@ class AuthInterceptor extends Interceptor {
     if (_cachedAccessToken == null) {
       _cachedAccessToken = await _tryRefreshBeforeRequest();
     } else if (TokenUtils.isExpired(_cachedAccessToken!)) {
-      _cachedAccessToken =
-          await _tryRefreshBeforeRequest() ?? _cachedAccessToken;
+      _cachedAccessToken = await _tryRefreshBeforeRequest();
+      if (_cachedAccessToken == null) {
+        await _handleRefreshFailure();
+      }
     }
 
     if (_cachedAccessToken != null) {
@@ -128,6 +130,9 @@ class AuthInterceptor extends Interceptor {
   Future<String?> _performRefresh() async {
     final refreshToken = await _storage.read(key: 'refresh_token');
     if (refreshToken == null || refreshToken.isEmpty) {
+      return null;
+    }
+    if (TokenUtils.isExpired(refreshToken)) {
       return null;
     }
 

--- a/lib/core/network/dio_client.dart
+++ b/lib/core/network/dio_client.dart
@@ -15,6 +15,7 @@ class DioClient {
   final Dio _dio;
   final FlutterSecureStorage _storage;
   final AppEnvironment _environment;
+  late final AuthInterceptor _authInterceptor;
 
   DioClient(this._storage, this._environment) : _dio = Dio() {
     configureHttpClientAdapter(
@@ -31,14 +32,13 @@ class DioClient {
         'Accept': 'application/json',
       };
 
-    _dio.interceptors.add(
-      AuthInterceptor(
-        _dio,
-        _storage,
-        _environment,
-        onLogout: authNotifier.logout,
-      ),
+    _authInterceptor = AuthInterceptor(
+      _dio,
+      _storage,
+      _environment,
+      onLogout: authNotifier.logout,
     );
+    _dio.interceptors.add(_authInterceptor);
 
     if (kDebugMode) {
       _dio.interceptors.add(
@@ -54,6 +54,8 @@ class DioClient {
   }
 
   Dio get dio => _dio;
+
+  Future<void> clearAuthCache() => _authInterceptor.clearCache();
 }
 
 final secureStorageProvider = Provider<FlutterSecureStorage>(

--- a/lib/core/notifications/notification_service.dart
+++ b/lib/core/notifications/notification_service.dart
@@ -11,6 +11,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:timezone/data/latest.dart' as tz;
 import 'package:timezone/timezone.dart' as tz;
 import 'package:washer/core/enums/laundry_machine_type.dart';
+import 'package:washer/core/enums/laundry_status.dart';
 import 'package:washer/core/network/dio_client.dart';
 import 'package:washer/features/reservation/data/models/local/active_reservation_model.dart';
 import 'package:washer/firebase_options.dart';
@@ -132,7 +133,7 @@ class NotificationService {
     final shouldSchedule =
         completionTime != null &&
         completionTime.isAfter(DateTime.now()) &&
-        (reservation.status == 'CONFIRMED' || reservation.status == 'IN_USE');
+        reservation.laundryStatus == LaundryStatus.inUse;
 
     if (!shouldSchedule) {
       await cancelScheduledCompletionNotification();

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -21,7 +21,10 @@ final appRouter = GoRouter(
   redirect: (context, state) async {
     final accessToken = await _storage.read(key: 'access_token');
     final refreshToken = await _storage.read(key: 'refresh_token');
-    final hasRefreshToken = refreshToken != null && refreshToken.isNotEmpty;
+    final hasRefreshToken =
+        refreshToken != null &&
+        refreshToken.isNotEmpty &&
+        !TokenUtils.isExpired(refreshToken);
     final hasValidAccessToken =
         accessToken != null &&
         accessToken.isNotEmpty &&

--- a/lib/core/ui/dialog/laundry_action_dialog.dart
+++ b/lib/core/ui/dialog/laundry_action_dialog.dart
@@ -56,16 +56,9 @@ class _LaundryActionDialogState extends ConsumerState<LaundryActionDialog> {
       switch (widget.actionType) {
         case LaundryActionType.reserve:
           navigator.pop();
-          final confirmState = await reservationNotifier.confirmAndWatch(
-            reservationId: widget.reservationId,
-          );
           messenger.showSnackBar(
-            SnackBar(
-              content: Text(
-                confirmState.status == ReservationActionStatus.success
-                    ? '기기 연결을 확인하고 있습니다.'
-                    : (confirmState.errorMessage ?? '시작 처리에 실패했습니다.'),
-              ),
+            const SnackBar(
+              content: Text('예약 후 자동으로 기기 연결 확인이 진행됩니다.'),
             ),
           );
           break;

--- a/lib/core/ui/dialog/laundry_status_dialog.dart
+++ b/lib/core/ui/dialog/laundry_status_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:washer/core/constants/durations.dart';
 import 'package:washer/core/enums/laundry_machine_type.dart';
 import 'package:washer/core/enums/machine_state.dart';
 import 'package:washer/core/theme/spacing.dart';
@@ -97,7 +98,8 @@ class LaundryStatusDialog extends ConsumerWidget {
                   messenger.showSnackBar(
                     SnackBar(
                       content: Text(
-                        '$machineName 예약이 완료되었습니다\n3분 동안 기기 연결을 확인합니다',
+                        '$machineName 예약이 완료되었습니다\n'
+                        '$reservationExpiryMinutes분 동안 기기 연결을 확인합니다',
                       ),
                     ),
                   );

--- a/lib/core/ui/dialog/laundry_status_dialog.dart
+++ b/lib/core/ui/dialog/laundry_status_dialog.dart
@@ -97,7 +97,7 @@ class LaundryStatusDialog extends ConsumerWidget {
                   messenger.showSnackBar(
                     SnackBar(
                       content: Text(
-                        '$machineName 예약이 완료되었습니다\n5분 이내에 기기를 켜주세요',
+                        '$machineName 예약이 완료되었습니다\n3분 동안 기기 연결을 확인합니다',
                       ),
                     ),
                   );

--- a/lib/core/utils/user_formatter.dart
+++ b/lib/core/utils/user_formatter.dart
@@ -1,0 +1,21 @@
+class UserFormatter {
+  const UserFormatter._();
+
+  static String? formatUserLabel({
+    required String? studentId,
+    required String? userName,
+  }) {
+    final normalizedStudentId = studentId?.trim();
+    final normalizedUserName = userName?.trim();
+
+    if (normalizedUserName == null || normalizedUserName.isEmpty) {
+      return null;
+    }
+
+    if (normalizedStudentId == null || normalizedStudentId.isEmpty) {
+      return normalizedUserName;
+    }
+
+    return '$normalizedStudentId $normalizedUserName';
+  }
+}

--- a/lib/features/auth/data/repositories/auth_repository.dart
+++ b/lib/features/auth/data/repositories/auth_repository.dart
@@ -17,11 +17,13 @@ class AuthRepositoryImpl implements AuthRepository {
   final AuthRemoteDataSource _dataSource;
   final FlutterSecureStorage _storage;
   final NotificationService _notificationService;
+  final DioClient _dioClient;
 
   const AuthRepositoryImpl(
     this._dataSource,
     this._storage,
     this._notificationService,
+    this._dioClient,
   );
 
   @override
@@ -71,8 +73,7 @@ class AuthRepositoryImpl implements AuthRepository {
     }
 
     await Future.wait([
-      _storage.delete(key: 'access_token'),
-      _storage.delete(key: 'refresh_token'),
+      _dioClient.clearAuthCache(),
       _notificationService.deleteStoredFcmToken(),
     ]);
   }
@@ -96,5 +97,6 @@ final authRepositoryProvider = Provider<AuthRepository>((ref) {
     ref.watch(authRemoteDataSourceProvider),
     ref.watch(secureStorageProvider),
     ref.watch(notificationServiceProvider),
+    ref.watch(dioClientProvider),
   );
 });

--- a/lib/features/home/presentation/widgets/home_my_reservation_widget.dart
+++ b/lib/features/home/presentation/widgets/home_my_reservation_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:washer/core/constants/durations.dart';
 import 'package:washer/core/enums/laundry_action_type.dart';
 import 'package:washer/core/enums/laundry_machine_type.dart';
 import 'package:washer/core/enums/laundry_status.dart';
@@ -365,7 +366,7 @@ class _ReservationExpiryText extends ConsumerWidget {
         : null;
     if (reservedTime != null) {
       countdown = _formatDuration(
-        reservedTime.add(const Duration(minutes: 3)).difference(now),
+        reservedTime.add(reservationExpiryDuration).difference(now),
         expiredText: '만료됨',
       );
     }

--- a/lib/features/home/presentation/widgets/home_my_reservation_widget.dart
+++ b/lib/features/home/presentation/widgets/home_my_reservation_widget.dart
@@ -11,6 +11,7 @@ import 'package:washer/core/ui/buttons/custom_small_button.dart';
 import 'package:washer/core/ui/dialog/laundry_action_dialog.dart';
 import 'package:washer/core/ui/reservation_state_widget.dart';
 import 'package:washer/core/utils/date_time_formatter.dart';
+import 'package:washer/core/utils/user_formatter.dart';
 import 'package:washer/features/home/presentation/viewmodels/home_view_model.dart';
 import 'package:washer/features/reservation/data/models/local/active_reservation_model.dart';
 import 'package:washer/features/user/presentation/viewmodels/my_user_view_model.dart';
@@ -206,10 +207,12 @@ class _ReservedUserInfo extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final userLabel = _buildUserLabel(
-      studentId: userStudentId,
-      userName: userName,
-    );
+    final userLabel =
+        UserFormatter.formatUserLabel(
+          studentId: userStudentId,
+          userName: userName,
+        ) ??
+        userName.trim();
     final message = '$userLabel 이용중...';
 
     return Text(
@@ -372,20 +375,6 @@ class _ReservationExpiryText extends ConsumerWidget {
       style: WasherTypography.body2(WasherColor.errorColor),
     );
   }
-}
-
-String _buildUserLabel({
-  required String? studentId,
-  required String userName,
-}) {
-  final normalizedStudentId = studentId?.trim();
-  final normalizedUserName = userName.trim();
-
-  if (normalizedStudentId == null || normalizedStudentId.isEmpty) {
-    return normalizedUserName;
-  }
-
-  return '$normalizedStudentId $normalizedUserName';
 }
 
 class _InUseCountdownText extends ConsumerWidget {

--- a/lib/features/home/presentation/widgets/home_my_reservation_widget.dart
+++ b/lib/features/home/presentation/widgets/home_my_reservation_widget.dart
@@ -234,11 +234,6 @@ class _ReservationBody extends StatelessWidget {
           reservedAt: reservedAt,
           remainDuration: remainDuration,
         );
-      case LaundryStatus.confirmed:
-        return _ConfirmedBody(
-          confirmedAt: confirmedAt,
-          finishedAt: finishedAt,
-        );
       case LaundryStatus.needConfirm:
         return const _NeedConfirmBody();
       case LaundryStatus.inUse:
@@ -280,41 +275,6 @@ class _WaitingBody extends StatelessWidget {
           _ReservationExpiryText(
             reservedAt: reservedAt,
             remainDuration: remainDuration,
-          ),
-          AppGap.v12,
-        ],
-      ],
-    );
-  }
-}
-
-class _ConfirmedBody extends StatelessWidget {
-  const _ConfirmedBody({
-    this.confirmedAt,
-    this.finishedAt,
-  });
-
-  final String? confirmedAt;
-  final String? finishedAt;
-
-  @override
-  Widget build(BuildContext context) {
-    final hasConfirmedAt =
-        confirmedAt != null && confirmedAt!.trim().isNotEmpty;
-    final hasFinishedAt = finishedAt != null && finishedAt!.trim().isNotEmpty;
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          '기기 연결을 확인하고 있습니다. 잠시만 기다려주세요.',
-          style: WasherTypography.body2(WasherColor.baseGray500),
-        ),
-        if (hasConfirmedAt || hasFinishedAt) ...[
-          AppGap.v4,
-          _ConfirmationCountdownText(
-            confirmedAt: confirmedAt,
-            finishedAt: finishedAt,
           ),
           AppGap.v12,
         ],
@@ -392,7 +352,7 @@ class _ReservationExpiryText extends ConsumerWidget {
         : null;
     if (reservedTime != null) {
       countdown = _formatDuration(
-        reservedTime.add(const Duration(minutes: 5)).difference(now),
+        reservedTime.add(const Duration(minutes: 3)).difference(now),
         expiredText: '만료됨',
       );
     }
@@ -400,33 +360,6 @@ class _ReservationExpiryText extends ConsumerWidget {
     return Text(
       '예약 만료까지: $countdown',
       style: WasherTypography.body2(WasherColor.errorColor),
-    );
-  }
-}
-
-class _ConfirmationCountdownText extends ConsumerWidget {
-  const _ConfirmationCountdownText({
-    this.confirmedAt,
-    this.finishedAt,
-  });
-
-  final String? confirmedAt;
-  final String? finishedAt;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final now = ref.watch(clockProvider).asData?.value ?? DateTime.now();
-    final baseTime =
-        (confirmedAt != null ? DateTime.tryParse(confirmedAt!) : null) ??
-        (finishedAt != null ? DateTime.tryParse(finishedAt!) : null);
-    final countdown = _formatDuration(
-      (baseTime ?? now).add(const Duration(minutes: 3)).difference(now),
-      expiredText: '만료됨',
-    );
-
-    return Text(
-      '예정 완료 시간: $countdown',
-      style: WasherTypography.body2(WasherColor.baseGray500),
     );
   }
 }
@@ -508,11 +441,7 @@ class _BottomSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final canCancel =
-        isOwnedByMe &&
-        (laundryStatus == LaundryStatus.reserved ||
-            laundryStatus == LaundryStatus.confirmed);
-    final canStart = isOwnedByMe && laundryStatus == LaundryStatus.reserved;
+    final canCancel = isOwnedByMe && laundryStatus == LaundryStatus.reserved;
 
     if (!canCancel || machineId == null) {
       return const SizedBox.shrink();
@@ -539,34 +468,6 @@ class _BottomSection extends StatelessWidget {
               }
             },
             color: WasherColor.baseGray300,
-          ),
-        ),
-        AppGap.h4,
-        Expanded(
-          child: CustomSmallButton(
-            text: '${laundryMachineType.text} 시작',
-            onPressed: () {
-              if (!canStart) {
-                return;
-              }
-
-              if (reservationId > 0) {
-                showDialog(
-                  context: context,
-                  builder: (context) => Dialog(
-                    child: LaundryActionDialog(
-                      actionType: LaundryActionType.reserve,
-                      deviceId: deviceId,
-                      reservationId: reservationId,
-                      machineId: machineId!,
-                    ),
-                  ),
-                );
-              }
-            },
-            color: canStart
-                ? WasherColor.mainColor400
-                : WasherColor.mainColor300,
           ),
         ),
       ],

--- a/lib/features/home/presentation/widgets/home_my_reservation_widget.dart
+++ b/lib/features/home/presentation/widgets/home_my_reservation_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:washer/core/enums/laundry_action_type.dart';
 import 'package:washer/core/enums/laundry_machine_type.dart';
 import 'package:washer/core/enums/laundry_status.dart';
@@ -17,7 +18,7 @@ import 'package:washer/features/user/presentation/viewmodels/my_user_view_model.
 class HomeMyReservationWidget extends ConsumerWidget {
   const HomeMyReservationWidget({super.key});
 
-  static const double _cardWidth = 360;
+  static final double _cardWidth = 348.w;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -171,10 +172,11 @@ class _MyReservationCard extends StatelessWidget {
             finishedAt: reservation.expectedCompletionTime,
           ),
           if (!isOwnedByMe) ...[
-            AppGap.v12,
+            AppGap.v4,
             _ReservedUserInfo(
+              laundryStatus: reservation.laundryStatus,
+              userStudentId: reservation.userStudentId,
               userName: reservation.userName,
-              roomNumber: reservation.userRoomNumber,
             ),
           ],
           _BottomSection(
@@ -193,17 +195,25 @@ class _MyReservationCard extends StatelessWidget {
 
 class _ReservedUserInfo extends StatelessWidget {
   const _ReservedUserInfo({
+    required this.laundryStatus,
+    this.userStudentId,
     required this.userName,
-    required this.roomNumber,
   });
 
+  final LaundryStatus laundryStatus;
+  final String? userStudentId;
   final String userName;
-  final String roomNumber;
 
   @override
   Widget build(BuildContext context) {
+    final userLabel = _buildUserLabel(
+      studentId: userStudentId,
+      userName: userName,
+    );
+    final message = '$userLabel 이용중...';
+
     return Text(
-      '예약자: $userName',
+      message,
       style: WasherTypography.body2(WasherColor.baseGray500),
     );
   }
@@ -364,6 +374,20 @@ class _ReservationExpiryText extends ConsumerWidget {
   }
 }
 
+String _buildUserLabel({
+  required String? studentId,
+  required String userName,
+}) {
+  final normalizedStudentId = studentId?.trim();
+  final normalizedUserName = userName.trim();
+
+  if (normalizedStudentId == null || normalizedStudentId.isEmpty) {
+    return normalizedUserName;
+  }
+
+  return '$normalizedStudentId $normalizedUserName';
+}
+
 class _InUseCountdownText extends ConsumerWidget {
   const _InUseCountdownText({
     required this.laundryMachineType,
@@ -441,9 +465,13 @@ class _BottomSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final canCancel = isOwnedByMe && laundryStatus == LaundryStatus.reserved;
+    if (!isOwnedByMe || machineId == null) {
+      return const SizedBox.shrink();
+    }
 
-    if (!canCancel || machineId == null) {
+    final canCancel = laundryStatus == LaundryStatus.reserved;
+
+    if (!canCancel) {
       return const SizedBox.shrink();
     }
 

--- a/lib/features/reservation/data/models/local/active_reservation_model.dart
+++ b/lib/features/reservation/data/models/local/active_reservation_model.dart
@@ -12,6 +12,7 @@ abstract class ActiveReservationModel with _$ActiveReservationModel {
   const factory ActiveReservationModel({
     required int id,
     required int userId,
+    String? userStudentId,
     required String userName,
     required String userRoomNumber,
     required int machineId,

--- a/lib/features/reservation/data/models/local/active_reservation_model.dart
+++ b/lib/features/reservation/data/models/local/active_reservation_model.dart
@@ -47,8 +47,6 @@ abstract class ActiveReservationModel with _$ActiveReservationModel {
     switch (normalizedStatus) {
       case 'RESERVED':
         return LaundryStatus.reserved;
-      case 'CONFIRMED':
-        return LaundryStatus.confirmed;
       case 'IN_USE':
       case 'RUNNING':
         return LaundryStatus.inUse;

--- a/lib/features/reservation/data/models/local/active_reservation_model.freezed.dart
+++ b/lib/features/reservation/data/models/local/active_reservation_model.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$ActiveReservationModel {
 
- int get id; int get userId; String get userName; String get userRoomNumber; int get machineId; String get machineName; String? get reservedAt; String? get confirmedAt; String? get startTime; String? get expectedCompletionTime; String? get actualCompletionTime; String get status;
+ int get id; int get userId; String? get userStudentId; String get userName; String get userRoomNumber; int get machineId; String get machineName; String? get reservedAt; String? get confirmedAt; String? get startTime; String? get expectedCompletionTime; String? get actualCompletionTime; String get status;
 /// Create a copy of ActiveReservationModel
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $ActiveReservationModelCopyWith<ActiveReservationModel> get copyWith => _$Active
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is ActiveReservationModel&&(identical(other.id, id) || other.id == id)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.userName, userName) || other.userName == userName)&&(identical(other.userRoomNumber, userRoomNumber) || other.userRoomNumber == userRoomNumber)&&(identical(other.machineId, machineId) || other.machineId == machineId)&&(identical(other.machineName, machineName) || other.machineName == machineName)&&(identical(other.reservedAt, reservedAt) || other.reservedAt == reservedAt)&&(identical(other.confirmedAt, confirmedAt) || other.confirmedAt == confirmedAt)&&(identical(other.startTime, startTime) || other.startTime == startTime)&&(identical(other.expectedCompletionTime, expectedCompletionTime) || other.expectedCompletionTime == expectedCompletionTime)&&(identical(other.actualCompletionTime, actualCompletionTime) || other.actualCompletionTime == actualCompletionTime)&&(identical(other.status, status) || other.status == status));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is ActiveReservationModel&&(identical(other.id, id) || other.id == id)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.userStudentId, userStudentId) || other.userStudentId == userStudentId)&&(identical(other.userName, userName) || other.userName == userName)&&(identical(other.userRoomNumber, userRoomNumber) || other.userRoomNumber == userRoomNumber)&&(identical(other.machineId, machineId) || other.machineId == machineId)&&(identical(other.machineName, machineName) || other.machineName == machineName)&&(identical(other.reservedAt, reservedAt) || other.reservedAt == reservedAt)&&(identical(other.confirmedAt, confirmedAt) || other.confirmedAt == confirmedAt)&&(identical(other.startTime, startTime) || other.startTime == startTime)&&(identical(other.expectedCompletionTime, expectedCompletionTime) || other.expectedCompletionTime == expectedCompletionTime)&&(identical(other.actualCompletionTime, actualCompletionTime) || other.actualCompletionTime == actualCompletionTime)&&(identical(other.status, status) || other.status == status));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,userId,userName,userRoomNumber,machineId,machineName,reservedAt,confirmedAt,startTime,expectedCompletionTime,actualCompletionTime,status);
+int get hashCode => Object.hash(runtimeType,id,userId,userStudentId,userName,userRoomNumber,machineId,machineName,reservedAt,confirmedAt,startTime,expectedCompletionTime,actualCompletionTime,status);
 
 @override
 String toString() {
-  return 'ActiveReservationModel(id: $id, userId: $userId, userName: $userName, userRoomNumber: $userRoomNumber, machineId: $machineId, machineName: $machineName, reservedAt: $reservedAt, confirmedAt: $confirmedAt, startTime: $startTime, expectedCompletionTime: $expectedCompletionTime, actualCompletionTime: $actualCompletionTime, status: $status)';
+  return 'ActiveReservationModel(id: $id, userId: $userId, userStudentId: $userStudentId, userName: $userName, userRoomNumber: $userRoomNumber, machineId: $machineId, machineName: $machineName, reservedAt: $reservedAt, confirmedAt: $confirmedAt, startTime: $startTime, expectedCompletionTime: $expectedCompletionTime, actualCompletionTime: $actualCompletionTime, status: $status)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $ActiveReservationModelCopyWith<$Res>  {
   factory $ActiveReservationModelCopyWith(ActiveReservationModel value, $Res Function(ActiveReservationModel) _then) = _$ActiveReservationModelCopyWithImpl;
 @useResult
 $Res call({
- int id, int userId, String userName, String userRoomNumber, int machineId, String machineName, String? reservedAt, String? confirmedAt, String? startTime, String? expectedCompletionTime, String? actualCompletionTime, String status
+ int id, int userId, String? userStudentId, String userName, String userRoomNumber, int machineId, String machineName, String? reservedAt, String? confirmedAt, String? startTime, String? expectedCompletionTime, String? actualCompletionTime, String status
 });
 
 
@@ -65,11 +65,12 @@ class _$ActiveReservationModelCopyWithImpl<$Res>
 
 /// Create a copy of ActiveReservationModel
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? userId = null,Object? userName = null,Object? userRoomNumber = null,Object? machineId = null,Object? machineName = null,Object? reservedAt = freezed,Object? confirmedAt = freezed,Object? startTime = freezed,Object? expectedCompletionTime = freezed,Object? actualCompletionTime = freezed,Object? status = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? userId = null,Object? userStudentId = freezed,Object? userName = null,Object? userRoomNumber = null,Object? machineId = null,Object? machineName = null,Object? reservedAt = freezed,Object? confirmedAt = freezed,Object? startTime = freezed,Object? expectedCompletionTime = freezed,Object? actualCompletionTime = freezed,Object? status = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as int,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
-as int,userName: null == userName ? _self.userName : userName // ignore: cast_nullable_to_non_nullable
+as int,userStudentId: freezed == userStudentId ? _self.userStudentId : userStudentId // ignore: cast_nullable_to_non_nullable
+as String?,userName: null == userName ? _self.userName : userName // ignore: cast_nullable_to_non_nullable
 as String,userRoomNumber: null == userRoomNumber ? _self.userRoomNumber : userRoomNumber // ignore: cast_nullable_to_non_nullable
 as String,machineId: null == machineId ? _self.machineId : machineId // ignore: cast_nullable_to_non_nullable
 as int,machineName: null == machineName ? _self.machineName : machineName // ignore: cast_nullable_to_non_nullable
@@ -164,10 +165,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  int userId,  String userName,  String userRoomNumber,  int machineId,  String machineName,  String? reservedAt,  String? confirmedAt,  String? startTime,  String? expectedCompletionTime,  String? actualCompletionTime,  String status)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  int userId,  String? userStudentId,  String userName,  String userRoomNumber,  int machineId,  String machineName,  String? reservedAt,  String? confirmedAt,  String? startTime,  String? expectedCompletionTime,  String? actualCompletionTime,  String status)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _ActiveReservationModel() when $default != null:
-return $default(_that.id,_that.userId,_that.userName,_that.userRoomNumber,_that.machineId,_that.machineName,_that.reservedAt,_that.confirmedAt,_that.startTime,_that.expectedCompletionTime,_that.actualCompletionTime,_that.status);case _:
+return $default(_that.id,_that.userId,_that.userStudentId,_that.userName,_that.userRoomNumber,_that.machineId,_that.machineName,_that.reservedAt,_that.confirmedAt,_that.startTime,_that.expectedCompletionTime,_that.actualCompletionTime,_that.status);case _:
   return orElse();
 
 }
@@ -185,10 +186,10 @@ return $default(_that.id,_that.userId,_that.userName,_that.userRoomNumber,_that.
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  int userId,  String userName,  String userRoomNumber,  int machineId,  String machineName,  String? reservedAt,  String? confirmedAt,  String? startTime,  String? expectedCompletionTime,  String? actualCompletionTime,  String status)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  int userId,  String? userStudentId,  String userName,  String userRoomNumber,  int machineId,  String machineName,  String? reservedAt,  String? confirmedAt,  String? startTime,  String? expectedCompletionTime,  String? actualCompletionTime,  String status)  $default,) {final _that = this;
 switch (_that) {
 case _ActiveReservationModel():
-return $default(_that.id,_that.userId,_that.userName,_that.userRoomNumber,_that.machineId,_that.machineName,_that.reservedAt,_that.confirmedAt,_that.startTime,_that.expectedCompletionTime,_that.actualCompletionTime,_that.status);case _:
+return $default(_that.id,_that.userId,_that.userStudentId,_that.userName,_that.userRoomNumber,_that.machineId,_that.machineName,_that.reservedAt,_that.confirmedAt,_that.startTime,_that.expectedCompletionTime,_that.actualCompletionTime,_that.status);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -205,10 +206,10 @@ return $default(_that.id,_that.userId,_that.userName,_that.userRoomNumber,_that.
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  int userId,  String userName,  String userRoomNumber,  int machineId,  String machineName,  String? reservedAt,  String? confirmedAt,  String? startTime,  String? expectedCompletionTime,  String? actualCompletionTime,  String status)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  int userId,  String? userStudentId,  String userName,  String userRoomNumber,  int machineId,  String machineName,  String? reservedAt,  String? confirmedAt,  String? startTime,  String? expectedCompletionTime,  String? actualCompletionTime,  String status)?  $default,) {final _that = this;
 switch (_that) {
 case _ActiveReservationModel() when $default != null:
-return $default(_that.id,_that.userId,_that.userName,_that.userRoomNumber,_that.machineId,_that.machineName,_that.reservedAt,_that.confirmedAt,_that.startTime,_that.expectedCompletionTime,_that.actualCompletionTime,_that.status);case _:
+return $default(_that.id,_that.userId,_that.userStudentId,_that.userName,_that.userRoomNumber,_that.machineId,_that.machineName,_that.reservedAt,_that.confirmedAt,_that.startTime,_that.expectedCompletionTime,_that.actualCompletionTime,_that.status);case _:
   return null;
 
 }
@@ -220,11 +221,12 @@ return $default(_that.id,_that.userId,_that.userName,_that.userRoomNumber,_that.
 @JsonSerializable()
 
 class _ActiveReservationModel extends ActiveReservationModel {
-  const _ActiveReservationModel({required this.id, required this.userId, required this.userName, required this.userRoomNumber, required this.machineId, required this.machineName, this.reservedAt, this.confirmedAt, this.startTime, this.expectedCompletionTime, this.actualCompletionTime, required this.status}): super._();
+  const _ActiveReservationModel({required this.id, required this.userId, this.userStudentId, required this.userName, required this.userRoomNumber, required this.machineId, required this.machineName, this.reservedAt, this.confirmedAt, this.startTime, this.expectedCompletionTime, this.actualCompletionTime, required this.status}): super._();
   factory _ActiveReservationModel.fromJson(Map<String, dynamic> json) => _$ActiveReservationModelFromJson(json);
 
 @override final  int id;
 @override final  int userId;
+@override final  String? userStudentId;
 @override final  String userName;
 @override final  String userRoomNumber;
 @override final  int machineId;
@@ -249,16 +251,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ActiveReservationModel&&(identical(other.id, id) || other.id == id)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.userName, userName) || other.userName == userName)&&(identical(other.userRoomNumber, userRoomNumber) || other.userRoomNumber == userRoomNumber)&&(identical(other.machineId, machineId) || other.machineId == machineId)&&(identical(other.machineName, machineName) || other.machineName == machineName)&&(identical(other.reservedAt, reservedAt) || other.reservedAt == reservedAt)&&(identical(other.confirmedAt, confirmedAt) || other.confirmedAt == confirmedAt)&&(identical(other.startTime, startTime) || other.startTime == startTime)&&(identical(other.expectedCompletionTime, expectedCompletionTime) || other.expectedCompletionTime == expectedCompletionTime)&&(identical(other.actualCompletionTime, actualCompletionTime) || other.actualCompletionTime == actualCompletionTime)&&(identical(other.status, status) || other.status == status));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _ActiveReservationModel&&(identical(other.id, id) || other.id == id)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.userStudentId, userStudentId) || other.userStudentId == userStudentId)&&(identical(other.userName, userName) || other.userName == userName)&&(identical(other.userRoomNumber, userRoomNumber) || other.userRoomNumber == userRoomNumber)&&(identical(other.machineId, machineId) || other.machineId == machineId)&&(identical(other.machineName, machineName) || other.machineName == machineName)&&(identical(other.reservedAt, reservedAt) || other.reservedAt == reservedAt)&&(identical(other.confirmedAt, confirmedAt) || other.confirmedAt == confirmedAt)&&(identical(other.startTime, startTime) || other.startTime == startTime)&&(identical(other.expectedCompletionTime, expectedCompletionTime) || other.expectedCompletionTime == expectedCompletionTime)&&(identical(other.actualCompletionTime, actualCompletionTime) || other.actualCompletionTime == actualCompletionTime)&&(identical(other.status, status) || other.status == status));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,id,userId,userName,userRoomNumber,machineId,machineName,reservedAt,confirmedAt,startTime,expectedCompletionTime,actualCompletionTime,status);
+int get hashCode => Object.hash(runtimeType,id,userId,userStudentId,userName,userRoomNumber,machineId,machineName,reservedAt,confirmedAt,startTime,expectedCompletionTime,actualCompletionTime,status);
 
 @override
 String toString() {
-  return 'ActiveReservationModel(id: $id, userId: $userId, userName: $userName, userRoomNumber: $userRoomNumber, machineId: $machineId, machineName: $machineName, reservedAt: $reservedAt, confirmedAt: $confirmedAt, startTime: $startTime, expectedCompletionTime: $expectedCompletionTime, actualCompletionTime: $actualCompletionTime, status: $status)';
+  return 'ActiveReservationModel(id: $id, userId: $userId, userStudentId: $userStudentId, userName: $userName, userRoomNumber: $userRoomNumber, machineId: $machineId, machineName: $machineName, reservedAt: $reservedAt, confirmedAt: $confirmedAt, startTime: $startTime, expectedCompletionTime: $expectedCompletionTime, actualCompletionTime: $actualCompletionTime, status: $status)';
 }
 
 
@@ -269,7 +271,7 @@ abstract mixin class _$ActiveReservationModelCopyWith<$Res> implements $ActiveRe
   factory _$ActiveReservationModelCopyWith(_ActiveReservationModel value, $Res Function(_ActiveReservationModel) _then) = __$ActiveReservationModelCopyWithImpl;
 @override @useResult
 $Res call({
- int id, int userId, String userName, String userRoomNumber, int machineId, String machineName, String? reservedAt, String? confirmedAt, String? startTime, String? expectedCompletionTime, String? actualCompletionTime, String status
+ int id, int userId, String? userStudentId, String userName, String userRoomNumber, int machineId, String machineName, String? reservedAt, String? confirmedAt, String? startTime, String? expectedCompletionTime, String? actualCompletionTime, String status
 });
 
 
@@ -286,11 +288,12 @@ class __$ActiveReservationModelCopyWithImpl<$Res>
 
 /// Create a copy of ActiveReservationModel
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? userId = null,Object? userName = null,Object? userRoomNumber = null,Object? machineId = null,Object? machineName = null,Object? reservedAt = freezed,Object? confirmedAt = freezed,Object? startTime = freezed,Object? expectedCompletionTime = freezed,Object? actualCompletionTime = freezed,Object? status = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? userId = null,Object? userStudentId = freezed,Object? userName = null,Object? userRoomNumber = null,Object? machineId = null,Object? machineName = null,Object? reservedAt = freezed,Object? confirmedAt = freezed,Object? startTime = freezed,Object? expectedCompletionTime = freezed,Object? actualCompletionTime = freezed,Object? status = null,}) {
   return _then(_ActiveReservationModel(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as int,userId: null == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
-as int,userName: null == userName ? _self.userName : userName // ignore: cast_nullable_to_non_nullable
+as int,userStudentId: freezed == userStudentId ? _self.userStudentId : userStudentId // ignore: cast_nullable_to_non_nullable
+as String?,userName: null == userName ? _self.userName : userName // ignore: cast_nullable_to_non_nullable
 as String,userRoomNumber: null == userRoomNumber ? _self.userRoomNumber : userRoomNumber // ignore: cast_nullable_to_non_nullable
 as String,machineId: null == machineId ? _self.machineId : machineId // ignore: cast_nullable_to_non_nullable
 as int,machineName: null == machineName ? _self.machineName : machineName // ignore: cast_nullable_to_non_nullable

--- a/lib/features/reservation/data/models/local/active_reservation_model.g.dart
+++ b/lib/features/reservation/data/models/local/active_reservation_model.g.dart
@@ -11,6 +11,7 @@ _ActiveReservationModel _$ActiveReservationModelFromJson(
 ) => _ActiveReservationModel(
   id: (json['id'] as num).toInt(),
   userId: (json['userId'] as num).toInt(),
+  userStudentId: json['userStudentId'] as String?,
   userName: json['userName'] as String,
   userRoomNumber: json['userRoomNumber'] as String,
   machineId: (json['machineId'] as num).toInt(),
@@ -28,6 +29,7 @@ Map<String, dynamic> _$ActiveReservationModelToJson(
 ) => <String, dynamic>{
   'id': instance.id,
   'userId': instance.userId,
+  'userStudentId': instance.userStudentId,
   'userName': instance.userName,
   'userRoomNumber': instance.userRoomNumber,
   'machineId': instance.machineId,

--- a/lib/features/reservation/data/models/local/laundry_machine_model.dart
+++ b/lib/features/reservation/data/models/local/laundry_machine_model.dart
@@ -35,6 +35,8 @@ abstract class MachineModel with _$MachineModel {
     int? remainingMinutes,
     int? reservationId,
     int? userId,
+    String? userStudentId,
+    String? userName,
     String? roomNumber,
   }) = _MachineModel;
 

--- a/lib/features/reservation/data/models/local/laundry_machine_model.freezed.dart
+++ b/lib/features/reservation/data/models/local/laundry_machine_model.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$MachineModel {
 
- int get machineId; String get name; String get type; String get status; String get availability; String? get operatingState; String? get jobState; String? get switchStatus; String? get expectedCompletionTime; int? get remainingMinutes; int? get reservationId; int? get userId; String? get roomNumber;
+ int get machineId; String get name; String get type; String get status; String get availability; String? get operatingState; String? get jobState; String? get switchStatus; String? get expectedCompletionTime; int? get remainingMinutes; int? get reservationId; int? get userId; String? get userStudentId; String? get userName; String? get roomNumber;
 /// Create a copy of MachineModel
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -28,16 +28,16 @@ $MachineModelCopyWith<MachineModel> get copyWith => _$MachineModelCopyWithImpl<M
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is MachineModel&&(identical(other.machineId, machineId) || other.machineId == machineId)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.status, status) || other.status == status)&&(identical(other.availability, availability) || other.availability == availability)&&(identical(other.operatingState, operatingState) || other.operatingState == operatingState)&&(identical(other.jobState, jobState) || other.jobState == jobState)&&(identical(other.switchStatus, switchStatus) || other.switchStatus == switchStatus)&&(identical(other.expectedCompletionTime, expectedCompletionTime) || other.expectedCompletionTime == expectedCompletionTime)&&(identical(other.remainingMinutes, remainingMinutes) || other.remainingMinutes == remainingMinutes)&&(identical(other.reservationId, reservationId) || other.reservationId == reservationId)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.roomNumber, roomNumber) || other.roomNumber == roomNumber));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is MachineModel&&(identical(other.machineId, machineId) || other.machineId == machineId)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.status, status) || other.status == status)&&(identical(other.availability, availability) || other.availability == availability)&&(identical(other.operatingState, operatingState) || other.operatingState == operatingState)&&(identical(other.jobState, jobState) || other.jobState == jobState)&&(identical(other.switchStatus, switchStatus) || other.switchStatus == switchStatus)&&(identical(other.expectedCompletionTime, expectedCompletionTime) || other.expectedCompletionTime == expectedCompletionTime)&&(identical(other.remainingMinutes, remainingMinutes) || other.remainingMinutes == remainingMinutes)&&(identical(other.reservationId, reservationId) || other.reservationId == reservationId)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.userStudentId, userStudentId) || other.userStudentId == userStudentId)&&(identical(other.userName, userName) || other.userName == userName)&&(identical(other.roomNumber, roomNumber) || other.roomNumber == roomNumber));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,machineId,name,type,status,availability,operatingState,jobState,switchStatus,expectedCompletionTime,remainingMinutes,reservationId,userId,roomNumber);
+int get hashCode => Object.hash(runtimeType,machineId,name,type,status,availability,operatingState,jobState,switchStatus,expectedCompletionTime,remainingMinutes,reservationId,userId,userStudentId,userName,roomNumber);
 
 @override
 String toString() {
-  return 'MachineModel(machineId: $machineId, name: $name, type: $type, status: $status, availability: $availability, operatingState: $operatingState, jobState: $jobState, switchStatus: $switchStatus, expectedCompletionTime: $expectedCompletionTime, remainingMinutes: $remainingMinutes, reservationId: $reservationId, userId: $userId, roomNumber: $roomNumber)';
+  return 'MachineModel(machineId: $machineId, name: $name, type: $type, status: $status, availability: $availability, operatingState: $operatingState, jobState: $jobState, switchStatus: $switchStatus, expectedCompletionTime: $expectedCompletionTime, remainingMinutes: $remainingMinutes, reservationId: $reservationId, userId: $userId, userStudentId: $userStudentId, userName: $userName, roomNumber: $roomNumber)';
 }
 
 
@@ -48,7 +48,7 @@ abstract mixin class $MachineModelCopyWith<$Res>  {
   factory $MachineModelCopyWith(MachineModel value, $Res Function(MachineModel) _then) = _$MachineModelCopyWithImpl;
 @useResult
 $Res call({
- int machineId, String name, String type, String status, String availability, String? operatingState, String? jobState, String? switchStatus, String? expectedCompletionTime, int? remainingMinutes, int? reservationId, int? userId, String? roomNumber
+ int machineId, String name, String type, String status, String availability, String? operatingState, String? jobState, String? switchStatus, String? expectedCompletionTime, int? remainingMinutes, int? reservationId, int? userId, String? userStudentId, String? userName, String? roomNumber
 });
 
 
@@ -65,7 +65,7 @@ class _$MachineModelCopyWithImpl<$Res>
 
 /// Create a copy of MachineModel
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? machineId = null,Object? name = null,Object? type = null,Object? status = null,Object? availability = null,Object? operatingState = freezed,Object? jobState = freezed,Object? switchStatus = freezed,Object? expectedCompletionTime = freezed,Object? remainingMinutes = freezed,Object? reservationId = freezed,Object? userId = freezed,Object? roomNumber = freezed,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? machineId = null,Object? name = null,Object? type = null,Object? status = null,Object? availability = null,Object? operatingState = freezed,Object? jobState = freezed,Object? switchStatus = freezed,Object? expectedCompletionTime = freezed,Object? remainingMinutes = freezed,Object? reservationId = freezed,Object? userId = freezed,Object? userStudentId = freezed,Object? userName = freezed,Object? roomNumber = freezed,}) {
   return _then(_self.copyWith(
 machineId: null == machineId ? _self.machineId : machineId // ignore: cast_nullable_to_non_nullable
 as int,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -79,7 +79,9 @@ as String?,expectedCompletionTime: freezed == expectedCompletionTime ? _self.exp
 as String?,remainingMinutes: freezed == remainingMinutes ? _self.remainingMinutes : remainingMinutes // ignore: cast_nullable_to_non_nullable
 as int?,reservationId: freezed == reservationId ? _self.reservationId : reservationId // ignore: cast_nullable_to_non_nullable
 as int?,userId: freezed == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
-as int?,roomNumber: freezed == roomNumber ? _self.roomNumber : roomNumber // ignore: cast_nullable_to_non_nullable
+as int?,userStudentId: freezed == userStudentId ? _self.userStudentId : userStudentId // ignore: cast_nullable_to_non_nullable
+as String?,userName: freezed == userName ? _self.userName : userName // ignore: cast_nullable_to_non_nullable
+as String?,roomNumber: freezed == roomNumber ? _self.roomNumber : roomNumber // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }
@@ -165,10 +167,10 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int machineId,  String name,  String type,  String status,  String availability,  String? operatingState,  String? jobState,  String? switchStatus,  String? expectedCompletionTime,  int? remainingMinutes,  int? reservationId,  int? userId,  String? roomNumber)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int machineId,  String name,  String type,  String status,  String availability,  String? operatingState,  String? jobState,  String? switchStatus,  String? expectedCompletionTime,  int? remainingMinutes,  int? reservationId,  int? userId,  String? userStudentId,  String? userName,  String? roomNumber)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _MachineModel() when $default != null:
-return $default(_that.machineId,_that.name,_that.type,_that.status,_that.availability,_that.operatingState,_that.jobState,_that.switchStatus,_that.expectedCompletionTime,_that.remainingMinutes,_that.reservationId,_that.userId,_that.roomNumber);case _:
+return $default(_that.machineId,_that.name,_that.type,_that.status,_that.availability,_that.operatingState,_that.jobState,_that.switchStatus,_that.expectedCompletionTime,_that.remainingMinutes,_that.reservationId,_that.userId,_that.userStudentId,_that.userName,_that.roomNumber);case _:
   return orElse();
 
 }
@@ -186,10 +188,10 @@ return $default(_that.machineId,_that.name,_that.type,_that.status,_that.availab
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int machineId,  String name,  String type,  String status,  String availability,  String? operatingState,  String? jobState,  String? switchStatus,  String? expectedCompletionTime,  int? remainingMinutes,  int? reservationId,  int? userId,  String? roomNumber)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int machineId,  String name,  String type,  String status,  String availability,  String? operatingState,  String? jobState,  String? switchStatus,  String? expectedCompletionTime,  int? remainingMinutes,  int? reservationId,  int? userId,  String? userStudentId,  String? userName,  String? roomNumber)  $default,) {final _that = this;
 switch (_that) {
 case _MachineModel():
-return $default(_that.machineId,_that.name,_that.type,_that.status,_that.availability,_that.operatingState,_that.jobState,_that.switchStatus,_that.expectedCompletionTime,_that.remainingMinutes,_that.reservationId,_that.userId,_that.roomNumber);case _:
+return $default(_that.machineId,_that.name,_that.type,_that.status,_that.availability,_that.operatingState,_that.jobState,_that.switchStatus,_that.expectedCompletionTime,_that.remainingMinutes,_that.reservationId,_that.userId,_that.userStudentId,_that.userName,_that.roomNumber);case _:
   throw StateError('Unexpected subclass');
 
 }
@@ -206,10 +208,10 @@ return $default(_that.machineId,_that.name,_that.type,_that.status,_that.availab
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int machineId,  String name,  String type,  String status,  String availability,  String? operatingState,  String? jobState,  String? switchStatus,  String? expectedCompletionTime,  int? remainingMinutes,  int? reservationId,  int? userId,  String? roomNumber)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int machineId,  String name,  String type,  String status,  String availability,  String? operatingState,  String? jobState,  String? switchStatus,  String? expectedCompletionTime,  int? remainingMinutes,  int? reservationId,  int? userId,  String? userStudentId,  String? userName,  String? roomNumber)?  $default,) {final _that = this;
 switch (_that) {
 case _MachineModel() when $default != null:
-return $default(_that.machineId,_that.name,_that.type,_that.status,_that.availability,_that.operatingState,_that.jobState,_that.switchStatus,_that.expectedCompletionTime,_that.remainingMinutes,_that.reservationId,_that.userId,_that.roomNumber);case _:
+return $default(_that.machineId,_that.name,_that.type,_that.status,_that.availability,_that.operatingState,_that.jobState,_that.switchStatus,_that.expectedCompletionTime,_that.remainingMinutes,_that.reservationId,_that.userId,_that.userStudentId,_that.userName,_that.roomNumber);case _:
   return null;
 
 }
@@ -221,7 +223,7 @@ return $default(_that.machineId,_that.name,_that.type,_that.status,_that.availab
 @JsonSerializable()
 
 class _MachineModel extends MachineModel {
-  const _MachineModel({required this.machineId, required this.name, required this.type, required this.status, required this.availability, this.operatingState, this.jobState, this.switchStatus, this.expectedCompletionTime, this.remainingMinutes, this.reservationId, this.userId, this.roomNumber}): super._();
+  const _MachineModel({required this.machineId, required this.name, required this.type, required this.status, required this.availability, this.operatingState, this.jobState, this.switchStatus, this.expectedCompletionTime, this.remainingMinutes, this.reservationId, this.userId, this.userStudentId, this.userName, this.roomNumber}): super._();
   factory _MachineModel.fromJson(Map<String, dynamic> json) => _$MachineModelFromJson(json);
 
 @override final  int machineId;
@@ -236,6 +238,8 @@ class _MachineModel extends MachineModel {
 @override final  int? remainingMinutes;
 @override final  int? reservationId;
 @override final  int? userId;
+@override final  String? userStudentId;
+@override final  String? userName;
 @override final  String? roomNumber;
 
 /// Create a copy of MachineModel
@@ -251,16 +255,16 @@ Map<String, dynamic> toJson() {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MachineModel&&(identical(other.machineId, machineId) || other.machineId == machineId)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.status, status) || other.status == status)&&(identical(other.availability, availability) || other.availability == availability)&&(identical(other.operatingState, operatingState) || other.operatingState == operatingState)&&(identical(other.jobState, jobState) || other.jobState == jobState)&&(identical(other.switchStatus, switchStatus) || other.switchStatus == switchStatus)&&(identical(other.expectedCompletionTime, expectedCompletionTime) || other.expectedCompletionTime == expectedCompletionTime)&&(identical(other.remainingMinutes, remainingMinutes) || other.remainingMinutes == remainingMinutes)&&(identical(other.reservationId, reservationId) || other.reservationId == reservationId)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.roomNumber, roomNumber) || other.roomNumber == roomNumber));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _MachineModel&&(identical(other.machineId, machineId) || other.machineId == machineId)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&(identical(other.status, status) || other.status == status)&&(identical(other.availability, availability) || other.availability == availability)&&(identical(other.operatingState, operatingState) || other.operatingState == operatingState)&&(identical(other.jobState, jobState) || other.jobState == jobState)&&(identical(other.switchStatus, switchStatus) || other.switchStatus == switchStatus)&&(identical(other.expectedCompletionTime, expectedCompletionTime) || other.expectedCompletionTime == expectedCompletionTime)&&(identical(other.remainingMinutes, remainingMinutes) || other.remainingMinutes == remainingMinutes)&&(identical(other.reservationId, reservationId) || other.reservationId == reservationId)&&(identical(other.userId, userId) || other.userId == userId)&&(identical(other.userStudentId, userStudentId) || other.userStudentId == userStudentId)&&(identical(other.userName, userName) || other.userName == userName)&&(identical(other.roomNumber, roomNumber) || other.roomNumber == roomNumber));
 }
 
 @JsonKey(includeFromJson: false, includeToJson: false)
 @override
-int get hashCode => Object.hash(runtimeType,machineId,name,type,status,availability,operatingState,jobState,switchStatus,expectedCompletionTime,remainingMinutes,reservationId,userId,roomNumber);
+int get hashCode => Object.hash(runtimeType,machineId,name,type,status,availability,operatingState,jobState,switchStatus,expectedCompletionTime,remainingMinutes,reservationId,userId,userStudentId,userName,roomNumber);
 
 @override
 String toString() {
-  return 'MachineModel(machineId: $machineId, name: $name, type: $type, status: $status, availability: $availability, operatingState: $operatingState, jobState: $jobState, switchStatus: $switchStatus, expectedCompletionTime: $expectedCompletionTime, remainingMinutes: $remainingMinutes, reservationId: $reservationId, userId: $userId, roomNumber: $roomNumber)';
+  return 'MachineModel(machineId: $machineId, name: $name, type: $type, status: $status, availability: $availability, operatingState: $operatingState, jobState: $jobState, switchStatus: $switchStatus, expectedCompletionTime: $expectedCompletionTime, remainingMinutes: $remainingMinutes, reservationId: $reservationId, userId: $userId, userStudentId: $userStudentId, userName: $userName, roomNumber: $roomNumber)';
 }
 
 
@@ -271,7 +275,7 @@ abstract mixin class _$MachineModelCopyWith<$Res> implements $MachineModelCopyWi
   factory _$MachineModelCopyWith(_MachineModel value, $Res Function(_MachineModel) _then) = __$MachineModelCopyWithImpl;
 @override @useResult
 $Res call({
- int machineId, String name, String type, String status, String availability, String? operatingState, String? jobState, String? switchStatus, String? expectedCompletionTime, int? remainingMinutes, int? reservationId, int? userId, String? roomNumber
+ int machineId, String name, String type, String status, String availability, String? operatingState, String? jobState, String? switchStatus, String? expectedCompletionTime, int? remainingMinutes, int? reservationId, int? userId, String? userStudentId, String? userName, String? roomNumber
 });
 
 
@@ -288,7 +292,7 @@ class __$MachineModelCopyWithImpl<$Res>
 
 /// Create a copy of MachineModel
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? machineId = null,Object? name = null,Object? type = null,Object? status = null,Object? availability = null,Object? operatingState = freezed,Object? jobState = freezed,Object? switchStatus = freezed,Object? expectedCompletionTime = freezed,Object? remainingMinutes = freezed,Object? reservationId = freezed,Object? userId = freezed,Object? roomNumber = freezed,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? machineId = null,Object? name = null,Object? type = null,Object? status = null,Object? availability = null,Object? operatingState = freezed,Object? jobState = freezed,Object? switchStatus = freezed,Object? expectedCompletionTime = freezed,Object? remainingMinutes = freezed,Object? reservationId = freezed,Object? userId = freezed,Object? userStudentId = freezed,Object? userName = freezed,Object? roomNumber = freezed,}) {
   return _then(_MachineModel(
 machineId: null == machineId ? _self.machineId : machineId // ignore: cast_nullable_to_non_nullable
 as int,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
@@ -302,7 +306,9 @@ as String?,expectedCompletionTime: freezed == expectedCompletionTime ? _self.exp
 as String?,remainingMinutes: freezed == remainingMinutes ? _self.remainingMinutes : remainingMinutes // ignore: cast_nullable_to_non_nullable
 as int?,reservationId: freezed == reservationId ? _self.reservationId : reservationId // ignore: cast_nullable_to_non_nullable
 as int?,userId: freezed == userId ? _self.userId : userId // ignore: cast_nullable_to_non_nullable
-as int?,roomNumber: freezed == roomNumber ? _self.roomNumber : roomNumber // ignore: cast_nullable_to_non_nullable
+as int?,userStudentId: freezed == userStudentId ? _self.userStudentId : userStudentId // ignore: cast_nullable_to_non_nullable
+as String?,userName: freezed == userName ? _self.userName : userName // ignore: cast_nullable_to_non_nullable
+as String?,roomNumber: freezed == roomNumber ? _self.roomNumber : roomNumber // ignore: cast_nullable_to_non_nullable
 as String?,
   ));
 }

--- a/lib/features/reservation/data/models/local/laundry_machine_model.g.dart
+++ b/lib/features/reservation/data/models/local/laundry_machine_model.g.dart
@@ -20,6 +20,8 @@ _MachineModel _$MachineModelFromJson(Map<String, dynamic> json) =>
       remainingMinutes: (json['remainingMinutes'] as num?)?.toInt(),
       reservationId: (json['reservationId'] as num?)?.toInt(),
       userId: (json['userId'] as num?)?.toInt(),
+      userStudentId: json['userStudentId'] as String?,
+      userName: json['userName'] as String?,
       roomNumber: json['roomNumber'] as String?,
     );
 
@@ -37,6 +39,8 @@ Map<String, dynamic> _$MachineModelToJson(_MachineModel instance) =>
       'remainingMinutes': instance.remainingMinutes,
       'reservationId': instance.reservationId,
       'userId': instance.userId,
+      'userStudentId': instance.userStudentId,
+      'userName': instance.userName,
       'roomNumber': instance.roomNumber,
     };
 

--- a/lib/features/reservation/presentation/viewmodels/reservation_view_model.dart
+++ b/lib/features/reservation/presentation/viewmodels/reservation_view_model.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:washer/core/enums/laundry_status.dart';
 import 'package:washer/features/home/data/repositories/home_repository.dart';
 import 'package:washer/features/home/presentation/viewmodels/home_view_model.dart';
 import 'package:washer/features/reservation/data/models/local/active_reservation_model.dart';
@@ -23,15 +24,14 @@ class ReservationActionState {
 }
 
 class ReservationViewModel extends Notifier<ReservationActionState> {
-  static const Duration _confirmPollingInterval = Duration(seconds: 10);
-  static const Duration _confirmPollingDuration = Duration(minutes: 3);
+  static const Duration _reservationPollingInterval = Duration(seconds: 10);
+  static const Duration _reservationPollingDuration = Duration(minutes: 3);
   static const Duration _finalSyncDelay = Duration(seconds: 1);
 
   Timer? _pollingTimer;
   Timer? _expiryTimer;
   Future<ReservationActionState>? _reserveRequest;
   Future<ReservationActionState>? _cancelRequest;
-  Future<ReservationActionState>? _confirmRequest;
 
   @override
   ReservationActionState build() => const ReservationActionState();
@@ -68,6 +68,7 @@ class ReservationViewModel extends Notifier<ReservationActionState> {
         reservation: createdReservation,
       );
       state = nextState;
+      _startPollingReservation();
       return nextState;
     } catch (e) {
       var errorMessage = '예약에 실패했습니다. 다시 시도해주세요.';
@@ -104,6 +105,8 @@ class ReservationViewModel extends Notifier<ReservationActionState> {
     );
 
     try {
+      _stopPolling();
+
       await ref
           .read(reservationRepositoryProvider)
           .cancelReservation(id: reservationId);
@@ -144,64 +147,15 @@ class ReservationViewModel extends Notifier<ReservationActionState> {
     _stopPolling();
   }
 
-  Future<ReservationActionState> confirmAndWatch({
-    required int reservationId,
-  }) async {
-    return _runSingleFlight(
-      currentRequest: _confirmRequest,
-      setRequest: (request) => _confirmRequest = request,
-      action: () => _confirmAndWatchInternal(reservationId: reservationId),
-    );
-  }
-
-  Future<ReservationActionState> _confirmAndWatchInternal({
-    required int reservationId,
-  }) async {
-    state = const ReservationActionState(
-      status: ReservationActionStatus.loading,
-    );
-
-    try {
-      await ref
-          .read(reservationRepositoryProvider)
-          .confirmReservation(id: reservationId);
-
-      await _refreshReservationData();
-
-      const nextState = ReservationActionState(
-        status: ReservationActionStatus.success,
-      );
-      state = nextState;
-      _startPollingReservation();
-      return nextState;
-    } catch (e) {
-      var errorMessage = '예약 확인에 실패했습니다.';
-      if (e is DioException && e.response?.data != null) {
-        final response = e.response!.data;
-        if (response is Map<String, dynamic> &&
-            response.containsKey('message')) {
-          errorMessage = response['message'] as String;
-        }
-      }
-
-      final nextState = ReservationActionState(
-        status: ReservationActionStatus.error,
-        errorMessage: errorMessage,
-      );
-      state = nextState;
-      return nextState;
-    }
-  }
-
   void _startPollingReservation() {
     _stopPolling();
 
-    _pollingTimer = Timer.periodic(_confirmPollingInterval, (_) {
+    _pollingTimer = Timer.periodic(_reservationPollingInterval, (_) {
       unawaited(_syncActiveReservation());
     });
 
     _expiryTimer = Timer(
-      _confirmPollingDuration + _finalSyncDelay,
+      _reservationPollingDuration + _finalSyncDelay,
       () {
         _stopPolling();
         unawaited(_syncActiveReservation(forceMachineRefresh: true));
@@ -238,6 +192,13 @@ class ReservationViewModel extends Notifier<ReservationActionState> {
           await ref.read(machineStatusProvider.notifier).refresh();
         }
         return;
+      }
+
+      final hasPendingReservation = latest.any(
+        (reservation) => reservation.laundryStatus == LaundryStatus.reserved,
+      );
+      if (!hasPendingReservation) {
+        _stopPolling();
       }
 
       final hasChanged = !_sameReservations(current, latest);

--- a/lib/features/reservation/presentation/viewmodels/reservation_view_model.dart
+++ b/lib/features/reservation/presentation/viewmodels/reservation_view_model.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:washer/core/constants/durations.dart';
 import 'package:washer/core/enums/laundry_status.dart';
 import 'package:washer/features/home/data/repositories/home_repository.dart';
 import 'package:washer/features/home/presentation/viewmodels/home_view_model.dart';
@@ -25,7 +26,7 @@ class ReservationActionState {
 
 class ReservationViewModel extends Notifier<ReservationActionState> {
   static const Duration _reservationPollingInterval = Duration(seconds: 10);
-  static const Duration _reservationPollingDuration = Duration(minutes: 3);
+  static const Duration _reservationPollingDuration = reservationExpiryDuration;
   static const Duration _finalSyncDelay = Duration(seconds: 1);
 
   Timer? _pollingTimer;

--- a/lib/features/reservation/presentation/widgets/reservation_section_widget.dart
+++ b/lib/features/reservation/presentation/widgets/reservation_section_widget.dart
@@ -74,9 +74,6 @@ class _ReservationSectionWidgetState
 
     if (isMyMachine && activeReservation != null) {
       final myReservation = activeReservation;
-      if (myReservation.laundryStatus == LaundryStatus.confirmed) {
-        return ReservationState.confirmed;
-      }
       if (myReservation.laundryStatus == LaundryStatus.inUse ||
           myReservation.laundryStatus == LaundryStatus.completed) {
         return ReservationState.inUse;
@@ -165,7 +162,7 @@ class _ReservationSectionWidgetState
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(
-              '${item.name} 예약이 완료되었습니다\n5분 이내에 기기를 켜주세요',
+              '${item.name} 예약이 완료되었습니다\n3분 동안 기기 연결을 확인합니다',
             ),
           ),
         );

--- a/lib/features/reservation/presentation/widgets/reservation_section_widget.dart
+++ b/lib/features/reservation/presentation/widgets/reservation_section_widget.dart
@@ -2,6 +2,7 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:washer/core/constants/durations.dart';
 import 'package:washer/core/enums/laundry_machine_type.dart';
 import 'package:washer/core/enums/laundry_status.dart';
 import 'package:washer/core/enums/reservation_state.dart';
@@ -169,7 +170,8 @@ class _ReservationSectionWidgetState
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(
-              '${item.name} 예약이 완료되었습니다\n3분 동안 기기 연결을 확인합니다',
+              '${item.name} 예약이 완료되었습니다\n'
+              '$reservationExpiryMinutes분 동안 기기 연결을 확인합니다',
             ),
           ),
         );

--- a/lib/features/reservation/presentation/widgets/reservation_section_widget.dart
+++ b/lib/features/reservation/presentation/widgets/reservation_section_widget.dart
@@ -123,11 +123,18 @@ class _ReservationSectionWidgetState
             machine.machineId,
             machine.name,
             state,
+            isOwnedByMe: isMyMachine,
             finishedAt: machine.expectedCompletionTime,
             room: room,
             reservedAt: reservedAt,
             remainDuration: null,
             reservationId: reservationId,
+            activeUserName: !isMyMachine
+                ? activeReservation?.userName ?? machine.userName
+                : null,
+            activeUserStudentId: !isMyMachine
+                ? activeReservation?.userStudentId ?? machine.userStudentId
+                : null,
           );
         })
         .toList(growable: false);
@@ -274,6 +281,9 @@ class _ReservationSectionWidgetState
                             reservedAt: item.reservedAt,
                             remainDuration: item.remainDuration,
                             reservationId: item.reservationId,
+                            activeUserName: item.activeUserName,
+                            activeUserStudentId: item.activeUserStudentId,
+                            showActions: item.isOwnedByMe,
                             onReserve:
                                 item.state == ReservationState.available &&
                                     !isReservationActionLoading
@@ -392,19 +402,25 @@ class _MachineData {
     this.machineId,
     this.name,
     this.state, {
+    this.isOwnedByMe = false,
     this.finishedAt,
     this.room,
     this.reservedAt,
     this.remainDuration,
     this.reservationId = 0,
+    this.activeUserName,
+    this.activeUserStudentId,
   });
 
   final int machineId;
   final String name;
   final ReservationState state;
+  final bool isOwnedByMe;
   final String? finishedAt;
   final String? room;
   final String? reservedAt;
   final String? remainDuration;
   final int reservationId;
+  final String? activeUserName;
+  final String? activeUserStudentId;
 }

--- a/lib/features/reservation/presentation/widgets/reservation_widget.dart
+++ b/lib/features/reservation/presentation/widgets/reservation_widget.dart
@@ -28,6 +28,9 @@ class ReservationWidget extends StatelessWidget {
     this.reservedAt,
     this.finishedAt,
     this.remainDuration,
+    this.activeUserName,
+    this.activeUserStudentId,
+    this.showActions = true,
     this.onReserve,
   });
 
@@ -40,6 +43,9 @@ class ReservationWidget extends StatelessWidget {
   final String? reservedAt;
   final String? finishedAt;
   final String? remainDuration;
+  final String? activeUserName;
+  final String? activeUserStudentId;
+  final bool showActions;
   final VoidCallback? onReserve;
 
   @override
@@ -103,6 +109,9 @@ class ReservationWidget extends StatelessWidget {
             reservedAt: reservedAt,
             finishedAt: finishedAt,
             remainDuration: remainDuration,
+            activeUserName: activeUserName,
+            activeUserStudentId: activeUserStudentId,
+            showActions: showActions,
             onReserve: onReserve,
           ),
         ],
@@ -123,6 +132,9 @@ class ReservationBottomSection extends StatelessWidget {
     this.reservedAt,
     this.finishedAt,
     this.remainDuration,
+    this.activeUserName,
+    this.activeUserStudentId,
+    this.showActions = true,
     this.onReserve,
   });
 
@@ -135,6 +147,9 @@ class ReservationBottomSection extends StatelessWidget {
   final String? reservedAt;
   final String? finishedAt;
   final String? remainDuration;
+  final String? activeUserName;
+  final String? activeUserStudentId;
+  final bool showActions;
   final VoidCallback? onReserve;
 
   @override
@@ -145,6 +160,8 @@ class ReservationBottomSection extends StatelessWidget {
           laundryMachineType: laundryMachineType,
           finishedAt: finishedAt,
           room: room,
+          activeUserName: activeUserName,
+          activeUserStudentId: activeUserStudentId,
         );
       case ReservationState.available:
         return _AvailableBottom(
@@ -160,6 +177,7 @@ class ReservationBottomSection extends StatelessWidget {
           machineId: machineId,
           reservationId: reservationId,
           machineName: machineName,
+          showActions: showActions,
         );
       case ReservationState.reservedByOther:
         return _ReservedBottom(
@@ -178,14 +196,23 @@ class _InUseBottom extends ConsumerWidget {
     required this.laundryMachineType,
     this.finishedAt,
     this.room,
+    this.activeUserName,
+    this.activeUserStudentId,
   });
 
   final LaundryMachineType laundryMachineType;
   final String? finishedAt;
   final String? room;
+  final String? activeUserName;
+  final String? activeUserStudentId;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final activeUserLabel = _buildActiveUserLabel(
+      studentId: activeUserStudentId,
+      userName: activeUserName,
+    );
+
     if (!_hasText(finishedAt)) {
       return Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -205,6 +232,13 @@ class _InUseBottom extends ConsumerWidget {
               '사용 호실: ${RoomFormatter.formatRoom(room)}',
               style: WasherTypography.body2(WasherColor.baseGray400),
             ),
+          if (activeUserLabel != null) ...[
+            AppGap.v4,
+            Text(
+              '$activeUserLabel 이용중...',
+              style: WasherTypography.body2(WasherColor.baseGray400),
+            ),
+          ],
         ],
       );
     }
@@ -235,12 +269,37 @@ class _InUseBottom extends ConsumerWidget {
             '사용 호실: ${RoomFormatter.formatRoom(room)}',
             style: WasherTypography.body2(WasherColor.baseGray400),
           ),
+        if (activeUserLabel != null) ...[
+          AppGap.v4,
+          Text(
+            '$activeUserLabel 이용중...',
+            style: WasherTypography.body2(WasherColor.baseGray400),
+          ),
+        ],
       ],
     );
   }
 }
 
 bool _hasText(String? value) => value != null && value.trim().isNotEmpty;
+
+String? _buildActiveUserLabel({
+  required String? studentId,
+  required String? userName,
+}) {
+  final normalizedStudentId = studentId?.trim();
+  final normalizedUserName = userName?.trim();
+
+  if (normalizedUserName == null || normalizedUserName.isEmpty) {
+    return null;
+  }
+
+  if (normalizedStudentId == null || normalizedStudentId.isEmpty) {
+    return normalizedUserName;
+  }
+
+  return '$normalizedStudentId $normalizedUserName';
+}
 
 class _AvailableBottom extends StatelessWidget {
   const _AvailableBottom({
@@ -328,6 +387,7 @@ class _ReservedByMeBottom extends StatelessWidget {
     required this.machineId,
     required this.reservationId,
     required this.machineName,
+    this.showActions = true,
   });
 
   final LaundryMachineType laundryMachineType;
@@ -335,6 +395,7 @@ class _ReservedByMeBottom extends StatelessWidget {
   final int machineId;
   final int reservationId;
   final String machineName;
+  final bool showActions;
 
   String _formatCountdown(DateTime expireAt, DateTime now) {
     final remaining = expireAt.difference(now);
@@ -357,29 +418,31 @@ class _ReservedByMeBottom extends StatelessWidget {
           reservedAt: reservedAt,
           formatCountdown: _formatCountdown,
         ),
-        AppGap.v12,
-        SizedBox(
-          width: double.infinity,
-          child: CustomBigButton(
-            text: '예약 취소',
-            onPressed: () {
-              if (reservationId > 0) {
-                showDialog(
-                  context: context,
-                  builder: (context) => Dialog(
-                    child: LaundryActionDialog(
-                      actionType: LaundryActionType.cancelReservation,
-                      deviceId: machineName,
-                      reservationId: reservationId,
-                      machineId: machineId,
+        if (showActions) ...[
+          AppGap.v12,
+          SizedBox(
+            width: double.infinity,
+            child: CustomBigButton(
+              text: '예약 취소',
+              onPressed: () {
+                if (reservationId > 0) {
+                  showDialog(
+                    context: context,
+                    builder: (context) => Dialog(
+                      child: LaundryActionDialog(
+                        actionType: LaundryActionType.cancelReservation,
+                        deviceId: machineName,
+                        reservationId: reservationId,
+                        machineId: machineId,
+                      ),
                     ),
-                  ),
-                );
-              }
-            },
-            color: WasherColor.baseGray300,
+                  );
+                }
+              },
+              color: WasherColor.baseGray300,
+            ),
           ),
-        ),
+        ],
       ],
     );
   }

--- a/lib/features/reservation/presentation/widgets/reservation_widget.dart
+++ b/lib/features/reservation/presentation/widgets/reservation_widget.dart
@@ -161,12 +161,6 @@ class ReservationBottomSection extends StatelessWidget {
           reservationId: reservationId,
           machineName: machineName,
         );
-      case ReservationState.confirmed:
-        return _ConfirmedByMeBottom(
-          laundryMachineType: laundryMachineType,
-          reservedAt: reservedAt,
-          finishedAt: finishedAt,
-        );
       case ReservationState.reservedByOther:
         return _ReservedBottom(
           reservedAt: reservedAt,
@@ -364,94 +358,28 @@ class _ReservedByMeBottom extends StatelessWidget {
           formatCountdown: _formatCountdown,
         ),
         AppGap.v12,
-        Row(
-          children: [
-            Expanded(
-              child: CustomBigButton(
-                text: '예약 취소',
-                onPressed: () {
-                  if (reservationId > 0) {
-                    showDialog(
-                      context: context,
-                      builder: (context) => Dialog(
-                        child: LaundryActionDialog(
-                          actionType: LaundryActionType.cancelReservation,
-                          deviceId: machineName,
-                          reservationId: reservationId,
-                          machineId: machineId,
-                        ),
-                      ),
-                    );
-                  }
-                },
-                color: WasherColor.baseGray300,
-              ),
-            ),
-            AppGap.h8,
-            Expanded(
-              child: CustomBigButton(
-                text: '${laundryMachineType.text} 시작',
-                onPressed: () {
-                  if (reservationId > 0) {
-                    showDialog(
-                      context: context,
-                      builder: (context) => Dialog(
-                        child: LaundryActionDialog(
-                          actionType: LaundryActionType.reserve,
-                          deviceId: machineName,
-                          reservationId: reservationId,
-                          machineId: machineId,
-                        ),
-                      ),
-                    );
-                  }
-                },
-                color: WasherColor.mainColor400,
-              ),
-            ),
-          ],
+        SizedBox(
+          width: double.infinity,
+          child: CustomBigButton(
+            text: '예약 취소',
+            onPressed: () {
+              if (reservationId > 0) {
+                showDialog(
+                  context: context,
+                  builder: (context) => Dialog(
+                    child: LaundryActionDialog(
+                      actionType: LaundryActionType.cancelReservation,
+                      deviceId: machineName,
+                      reservationId: reservationId,
+                      machineId: machineId,
+                    ),
+                  ),
+                );
+              }
+            },
+            color: WasherColor.baseGray300,
+          ),
         ),
-      ],
-    );
-  }
-}
-
-class _ConfirmedByMeBottom extends StatelessWidget {
-  const _ConfirmedByMeBottom({
-    required this.laundryMachineType,
-    this.reservedAt,
-    this.finishedAt,
-  });
-
-  final LaundryMachineType laundryMachineType;
-  final String? reservedAt;
-  final String? finishedAt;
-
-  String _formatCountdown(DateTime? baseTime, DateTime now) {
-    if (baseTime == null) return '';
-    final expiryTime = baseTime.add(const Duration(minutes: 3));
-    final remaining = expiryTime.difference(now);
-    if (remaining.isNegative) return '만료됨';
-
-    return DateTimeFormatter.formatDurationParts(remaining);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Text(
-          '기기 연결을 확인하고 있습니다. 잠시만 기다려주세요.',
-          style: WasherTypography.body2(WasherColor.baseGray500),
-        ),
-        AppGap.v4,
-        _ConfirmedByMeCountdownText(
-          reservedAt: reservedAt,
-          finishedAt: finishedAt,
-          formatCountdown: _formatCountdown,
-        ),
-        AppGap.v12,
       ],
     );
   }
@@ -472,41 +400,11 @@ class _ReservedByMeCountdownText extends ConsumerWidget {
     final reservedTime = reservedAt != null
         ? DateTime.tryParse(reservedAt!)
         : null;
-    final expireAt = reservedTime?.add(const Duration(minutes: 5));
+    final expireAt = reservedTime?.add(const Duration(minutes: 3));
 
     return Text(
       '예약 만료까지: ${expireAt != null ? formatCountdown(expireAt, now) : ''}',
       style: WasherTypography.body2(WasherColor.errorColor),
-    );
-  }
-}
-
-class _ConfirmedByMeCountdownText extends ConsumerWidget {
-  const _ConfirmedByMeCountdownText({
-    required this.reservedAt,
-    required this.finishedAt,
-    required this.formatCountdown,
-  });
-
-  final String? reservedAt;
-  final String? finishedAt;
-  final String Function(DateTime? baseTime, DateTime now) formatCountdown;
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final now = ref.watch(clockProvider).asData?.value ?? DateTime.now();
-    final reservedTime = reservedAt != null
-        ? DateTime.tryParse(reservedAt!)
-        : null;
-    final countdown = reservedTime != null
-        ? formatCountdown(reservedTime, now)
-        : (finishedAt != null
-              ? formatCountdown(DateTime.tryParse(finishedAt!), now)
-              : '');
-
-    return Text(
-      '예정 완료 시간: $countdown',
-      style: WasherTypography.body2(WasherColor.baseGray500),
     );
   }
 }

--- a/lib/features/reservation/presentation/widgets/reservation_widget.dart
+++ b/lib/features/reservation/presentation/widgets/reservation_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:washer/core/constants/durations.dart';
 import 'package:washer/core/enums/laundry_action_type.dart';
 import 'package:washer/core/enums/laundry_machine_type.dart';
 import 'package:washer/core/enums/reservation_state.dart';
@@ -446,7 +447,7 @@ class _ReservedByMeCountdownText extends ConsumerWidget {
     final reservedTime = reservedAt != null
         ? DateTime.tryParse(reservedAt!)
         : null;
-    final expireAt = reservedTime?.add(const Duration(minutes: 3));
+    final expireAt = reservedTime?.add(reservationExpiryDuration);
 
     return Text(
       '예약 만료까지: ${expireAt != null ? formatCountdown(expireAt, now) : ''}',

--- a/lib/features/reservation/presentation/widgets/reservation_widget.dart
+++ b/lib/features/reservation/presentation/widgets/reservation_widget.dart
@@ -13,6 +13,7 @@ import 'package:washer/core/ui/dialog/laundry_action_dialog.dart';
 import 'package:washer/core/ui/reservation_state_widget.dart';
 import 'package:washer/core/utils/date_time_formatter.dart';
 import 'package:washer/core/utils/room_formatter.dart';
+import 'package:washer/core/utils/user_formatter.dart';
 import 'package:washer/features/history/presentation/widgets/history_dialog.dart';
 import 'package:washer/features/home/presentation/viewmodels/home_view_model.dart';
 
@@ -208,7 +209,7 @@ class _InUseBottom extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final activeUserLabel = _buildActiveUserLabel(
+    final activeUserLabel = UserFormatter.formatUserLabel(
       studentId: activeUserStudentId,
       userName: activeUserName,
     );
@@ -282,24 +283,6 @@ class _InUseBottom extends ConsumerWidget {
 }
 
 bool _hasText(String? value) => value != null && value.trim().isNotEmpty;
-
-String? _buildActiveUserLabel({
-  required String? studentId,
-  required String? userName,
-}) {
-  final normalizedStudentId = studentId?.trim();
-  final normalizedUserName = userName?.trim();
-
-  if (normalizedUserName == null || normalizedUserName.isEmpty) {
-    return null;
-  }
-
-  if (normalizedStudentId == null || normalizedStudentId.isEmpty) {
-    return normalizedUserName;
-  }
-
-  return '$normalizedStudentId $normalizedUserName';
-}
 
 class _AvailableBottom extends StatelessWidget {
   const _AvailableBottom({

--- a/lib/splash_screen.dart
+++ b/lib/splash_screen.dart
@@ -32,7 +32,10 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
     final accessToken = await storage.read(key: 'access_token');
     final refreshToken = await storage.read(key: 'refresh_token');
     final hasAccessToken = accessToken != null && accessToken.isNotEmpty;
-    final hasRefreshToken = refreshToken != null && refreshToken.isNotEmpty;
+    final hasRefreshToken =
+        refreshToken != null &&
+        refreshToken.isNotEmpty &&
+        !TokenUtils.isExpired(refreshToken);
 
     if (!hasAccessToken && !hasRefreshToken) {
       await _goToLogin(storage);


### PR DESCRIPTION
## 💡 개요
예약 흐름에서 상태 표기를 정리하고, 예약 화면에 실제 사용자를 더 명확히 노출하도록 개선했습니다. 함께 인증 토큰 만료 처리와 로그아웃 시 인터셉터 캐시 정리도 보강했습니다.

## 🔗 관련 이슈
<!-- 이 PR과 관련된 이슈 번호를 작성해주세요. PR이 머지되면 자동으로 이슈가 닫힙니다. -->
<!-- 예시: Closes #123, Fixes #456 -->
Closes #128

## 📃 작업내용
<!-- 주요 변경사항을 상세히 나열해주세요 -->
- 만료된 리프레시 토큰을 라우터, 스플래시, 인증 인터셉터에서 공통으로 걸러내도록 정리했습니다.
- 로그아웃 시 Dio 인증 인터셉터 캐시까지 함께 정리하도록 수정했습니다.
- 예약/사용중 카드에 학번과 이름 기반의 사용자 정보를 노출하도록 모델과 UI를 확장했습니다.
- 본인 예약이 아닌 경우 예약 취소 액션이 노출되지 않도록 화면 동작을 조정했습니다.
- 홈 예약 카드 너비와 하단 정보 구성을 예약 상태에 맞게 다듬었습니다.

## 🔍 테스트 방법
<!-- 이 PR을 테스트하는 방법을 설명해주세요 -->
- `flutter test` 실행
- 현재 `test/widget_test.dart`의 기본 스모크 테스트가 기존 구조와 맞지 않아 실패하는 것을 확인했습니다.

## 🖼️ 스크린샷
<!-- 필요한 경우 스크린샷을 첨부해주세요 -->

## 🙋‍♂️ 질문사항
<!-- 리뷰어에게 특별히 확인받고 싶은 부분이 있다면 작성해주세요 -->
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

## ✅ 체크리스트
<!-- PR을 제출하기 전에 다음 항목을 확인해주세요 -->
- [ ] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [x] 불필요한 코드가 없는지 확인했습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [ ] 기존 기능이 정상적으로 작동하는지 확인했습니다. 
