### PR TITLE
🔀 :: (#144) - Android/iOS CI 빌드 환경 설정 누락 오류 수정

### DIFF
--- a/.github/workflows/cd-android.yml
+++ b/.github/workflows/cd-android.yml
@@ -52,9 +52,11 @@ jobs:
           ANDROID_KEY_PROPERTIES: ${{ secrets.ANDROID_KEY_PROPERTIES }}
           ANDROID_GOOGLE_SERVICES_JSON: ${{ secrets.ANDROID_GOOGLE_SERVICES_JSON }}
           ENV_PRODUCTION: ${{ secrets.ENV_PRODUCTION }}
+          ENV_DEVELOPMENT: ${{ secrets.ENV_DEVELOPMENT }}
         run: |
           if [ -z "$ANDROID_KEYSTORE_BASE64" ] || [ -z "$ANDROID_KEY_PROPERTIES" ] || \
-             [ -z "$ANDROID_GOOGLE_SERVICES_JSON" ] || [ -z "$ENV_PRODUCTION" ]; then
+             [ -z "$ANDROID_GOOGLE_SERVICES_JSON" ] || [ -z "$ENV_PRODUCTION" ] || \
+             [ -z "$ENV_DEVELOPMENT" ]; then
             echo "::error::Required release secrets are missing."
             exit 1
           fi
@@ -70,6 +72,7 @@ jobs:
           printf '%s' "$ANDROID_KEY_PROPERTIES" > android/key.properties
           printf '%s' "$ANDROID_GOOGLE_SERVICES_JSON" > android/app/google-services.json
           printf '%s' "$ENV_PRODUCTION" > .env.production
+          printf '%s' "$ENV_DEVELOPMENT" > .env.development
 
       - name: Resolve Android version metadata
         run: |
@@ -99,3 +102,4 @@ jobs:
           rm -f android/key.properties
           rm -f android/app/google-services.json
           rm -f .env.production
+          rm -f .env.development

--- a/.github/workflows/cd-ios.yml
+++ b/.github/workflows/cd-ios.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Flutter pub get
         run: fvm flutter pub get
 
+      - name: Flutter precache iOS artifacts
+        run: fvm flutter precache --ios
+
       - name: Install CocoaPods dependencies
         working-directory: ios
         run: pod install


### PR DESCRIPTION
## 💡 개요
Android CI에서 `.env.development` 파일 누락 및 iOS CI에서 `flutter precache --ios` 미실행으로 인한 빌드 실패 문제를 수정합니다.

## 🔗 관련 이슈
Closes #144

## 📃 작업내용
- `cd-android.yml`: GitHub Secret으로 `.env.development` 파일 생성 step 추가 및 빌드 후 cleanup 처리 추가
- `cd-ios.yml`: `pod install` 이전에 `fvm flutter precache --ios` step 추가

## 🔍 테스트 방법
- GitHub Repository Settings → Secrets에 `ENV_DEVELOPMENT` secret 등록 확인
- Android CD 파이프라인 빌드 성공 확인
- iOS CD 파이프라인 `pod install` 단계 정상 통과 확인

## 🖼️ 스크린샷

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

## ✅ 체크리스트
- [ ] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [ ] 불필요한 코드가 없는지 확인했습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 기존 기능이 정상적으로 작동하는지 확인했습니다.