### PR TITLE
🔀 :: (#146) - Android CI AAB 파일 경로 탐색 오류를 수정하겠습니다

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,3 +1,5 @@
+WORKSPACE = ENV.fetch("GITHUB_WORKSPACE", File.expand_path("..", __dir__))
+
 default_platform(:ios)
 
 platform :ios do
@@ -27,10 +29,9 @@ platform :ios do
     )
 
     # flutter build ipa는 CFBundleName 기준으로 IPA 파일명을 생성하므로 glob으로 탐색
-    # CI 환경에서 작업 디렉토리가 다를 수 있으므로 절대경로로 탐색
-    workspace = ENV.fetch("GITHUB_WORKSPACE", File.expand_path("..", __dir__))
-    ipa_path = Dir.glob("#{workspace}/build/ios/ipa/*.ipa").first
-    UI.user_error!("IPA not found in #{workspace}/build/ios/ipa/") if ipa_path.nil?
+    ipa_search_path = File.join(WORKSPACE, "build/ios/ipa")
+    ipa_path = Dir.glob(File.join(ipa_search_path, "*.ipa")).max_by { |f| File.mtime(f) }
+    UI.user_error!("IPA not found in #{ipa_search_path}") if ipa_path.nil?
 
     upload_to_testflight(
       ipa: ipa_path,
@@ -58,10 +59,9 @@ platform :android do
       ].join(" ")
     )
 
-    # CI 환경에서 작업 디렉토리가 다를 수 있으므로 절대경로로 탐색
-    workspace = ENV.fetch("GITHUB_WORKSPACE", File.expand_path("..", __dir__))
-    aab_path = Dir.glob("#{workspace}/build/app/outputs/bundle/release/*.aab").first
-    UI.user_error!("AAB not found in #{workspace}/build/app/outputs/bundle/release/") if aab_path.nil?
+    aab_search_path = File.join(WORKSPACE, "build/app/outputs/bundle/release")
+    aab_path = Dir.glob(File.join(aab_search_path, "*.aab")).max_by { |f| File.mtime(f) }
+    UI.user_error!("AAB not found in #{aab_search_path}") if aab_path.nil?
 
     upload_to_play_store(
       track: "internal",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -27,8 +27,10 @@ platform :ios do
     )
 
     # flutter build ipa는 CFBundleName 기준으로 IPA 파일명을 생성하므로 glob으로 탐색
-    ipa_path = Dir.glob("build/ios/ipa/*.ipa").first
-    UI.user_error!("IPA not found in build/ios/ipa/") if ipa_path.nil?
+    # CI 환경에서 작업 디렉토리가 다를 수 있으므로 절대경로로 탐색
+    workspace = ENV.fetch("GITHUB_WORKSPACE", File.expand_path("..", __dir__))
+    ipa_path = Dir.glob("#{workspace}/build/ios/ipa/*.ipa").first
+    UI.user_error!("IPA not found in #{workspace}/build/ios/ipa/") if ipa_path.nil?
 
     upload_to_testflight(
       ipa: ipa_path,
@@ -56,8 +58,10 @@ platform :android do
       ].join(" ")
     )
 
-    aab_path = Dir.glob("build/app/outputs/bundle/release/*.aab").first
-    UI.user_error!("AAB not found in build/app/outputs/bundle/release/") if aab_path.nil?
+    # CI 환경에서 작업 디렉토리가 다를 수 있으므로 절대경로로 탐색
+    workspace = ENV.fetch("GITHUB_WORKSPACE", File.expand_path("..", __dir__))
+    aab_path = Dir.glob("#{workspace}/build/app/outputs/bundle/release/*.aab").first
+    UI.user_error!("AAB not found in #{workspace}/build/app/outputs/bundle/release/") if aab_path.nil?
 
     upload_to_play_store(
       track: "internal",


### PR DESCRIPTION
## 💡 개요
Android CI 빌드 후 AAB 파일 경로를 찾지 못해 업로드 단계에서 실패하는 문제를 수정합니다.

## 🔗 관련 이슈
Closes #146

## 📃 작업내용
- `Fastfile`: 상대경로 방식의 aab_path 탐색 로직을 `__dir__` 기반 절대경로 방식으로 수정

## 🔍 테스트 방법
- Android CD 파이프라인 빌드 및 업로드 성공 확인

## 🖼️ 스크린샷

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

## ✅ 체크리스트
- [ ] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [ ] 불필요한 코드가 없는지 확인했습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 기존 기능이 정상적으로 작동하는지 확인했습니다.