### PR TITLE
🔀 :: (#150) - iOS CI CocoaPods Ruby 버전 충돌 오류를 수정하겠습니다

### DIFF
--- a/.github/workflows/cd-ios.yml
+++ b/.github/workflows/cd-ios.yml
@@ -48,6 +48,11 @@ jobs:
       - name: Flutter precache iOS artifacts
         run: fvm flutter precache --ios
 
+      - name: Reinstall CocoaPods
+        run: |
+          sudo gem uninstall cocoapods --all --ignore-dependencies
+          sudo gem install cocoapods
+
       - name: Install CocoaPods dependencies
         working-directory: ios
         run: pod install


### PR DESCRIPTION
## 💡 개요
iOS CI 빌드 시 CocoaPods가 설치된 Ruby 버전과 실행 중인 Ruby 버전이
달라 CocoaPods가 정상 동작하지 않아 빌드가 실패하는 문제를 수정합니다.

## 🔗 관련 이슈
Closes #150

## 📃 작업내용
- `cd-ios.yml`: pod install 이전에 CocoaPods 재설치 step 추가

## 🔍 테스트 방법
- iOS CD 파이프라인 pod install 단계 정상 통과 확인
- iOS CD 파이프라인 빌드 및 TestFlight 업로드 성공 확인

## 🖼️ 스크린샷

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

## ✅ 체크리스트
- [ ] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [ ] 불필요한 코드가 없는지 확인했습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 기존 기능이 정상적으로 작동하는지 확인했습니다.