### PR TITLE
🔀 :: (#152) - iOS CI Ruby 버전을 3.3으로 업그레이드하겠습니다

### DIFF
--- a/.github/workflows/cd-ios.yml
+++ b/.github/workflows/cd-ios.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: '3.3'
           bundler-cache: true
 
       - name: Flutter pub get
@@ -47,11 +47,6 @@ jobs:
 
       - name: Flutter precache iOS artifacts
         run: fvm flutter precache --ios
-
-      - name: Reinstall CocoaPods
-        run: |
-          sudo gem uninstall cocoapods --all --ignore-dependencies
-          sudo gem install cocoapods
 
       - name: Install CocoaPods dependencies
         working-directory: ios


### PR DESCRIPTION
## 💡 개요
iOS CI 빌드 시 Ruby 3.2 환경에서 CocoaPods가 정상 동작하지 않아
빌드가 반복적으로 실패하는 문제를 Ruby 버전 업그레이드로 근본 해결합니다.

## 🔗 관련 이슈
Closes #152

## 📃 작업내용
- `cd-ios.yml`: Ruby 버전 3.2 → 3.3 업그레이드
- `cd-ios.yml`: 비효율적인 CocoaPods 재설치 step 제거

## 🔍 테스트 방법
- iOS CD 파이프라인 pod install 단계 정상 통과 확인
- iOS CD 파이프라인 빌드 및 TestFlight 업로드 성공 확인

## 🖼️ 스크린샷


## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

## ✅ 체크리스트
- [ ] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [ ] 불필요한 코드가 없는지 확인했습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 기존 기능이 정상적으로 작동하는지 확인했습니다.