### PR TITLE
🔀 :: (#154) - iOS CI CocoaPods를 Bundler로 관리하도록 변경하겠습니다

### DIFF
--- a/.github/workflows/cd-ios.yml
+++ b/.github/workflows/cd-ios.yml
@@ -42,6 +42,11 @@ jobs:
           ruby-version: '3.3'
           bundler-cache: true
 
+      - name: Export CocoaPods bin to PATH
+        run: |
+          bundle binstubs cocoapods
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+
       - name: Flutter pub get
         run: fvm flutter pub get
 
@@ -50,7 +55,7 @@ jobs:
 
       - name: Install CocoaPods dependencies
         working-directory: ios
-        run: pod install
+        run: bundle exec pod install
 
       - name: Restore production env
         env:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "fastlane"
+gem "cocoapods"

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
 gem "fastlane"
-gem "cocoapods"
+gem "cocoapods", "~> 1.16.2"


### PR DESCRIPTION
## 💡 개요
iOS CI 빌드 시 Flutter 내부에서 시스템 CocoaPods를 참조해
Ruby 버전 충돌로 빌드가 반복적으로 실패하는 문제를
CocoaPods를 Bundler로 관리하여 근본적으로 해결합니다.

## 🔗 관련 이슈
Closes #154

## 📃 작업내용
- `Gemfile`: gem "cocoapods" 추가
- `cd-ios.yml`: bundle binstubs cocoapods로 로컬 stub 생성 후 PATH 등록
- `cd-ios.yml`: pod install → bundle exec pod install로 변경
- `cd-ios.yml`: Reinstall CocoaPods step 제거

## 🔍 테스트 방법
- iOS CD 파이프라인 pod install 단계 정상 통과 확인
- iOS CD 파이프라인 빌드 및 TestFlight 업로드 성공 확인

## 🖼️ 스크린샷


## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

## ✅ 체크리스트
- [ ] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [ ] 불필요한 코드가 없는지 확인했습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 기존 기능이 정상적으로 작동하는지 확인했습니다.