### PR TITLE
🔀 :: (#156) - iOS CI 빌드 방식을 Fastlane build_app으로 변경하겠습니다

### DIFF
--- a/.github/workflows/cd-ios.yml
+++ b/.github/workflows/cd-ios.yml
@@ -112,7 +112,7 @@ jobs:
           echo "IOS_BUILD_NUMBER=${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
           echo "TESTFLIGHT_CHANGELOG=main branch build #${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
 
-      - name: Upload to TestFlight
+      - name: Build & Upload to TestFlight
         env:
           APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -18,23 +18,23 @@ platform :ios do
 
     sh(
       [
-        "fvm", "flutter", "build", "ipa",
+        "fvm", "flutter", "build", "ios",
         "--release",
+        "--no-codesign",
         "--build-name=#{version_name}",
         "--build-number=#{build_number}",
-        "--dart-define=APP_ENV=production",
-        # Flutter 3.22+에서 --export-method 제거됨. ExportOptions.plist로 대체.
-        "--export-options-plist=\"#{File.join(WORKSPACE, 'ios', 'ExportOptions.plist')}\""
+        "--dart-define=APP_ENV=production"
       ].join(" ")
     )
 
-    # flutter build ipa는 CFBundleName 기준으로 IPA 파일명을 생성하므로 glob으로 탐색
-    ipa_search_path = File.join(WORKSPACE, "build/ios/ipa")
-    ipa_path = Dir.glob(File.join(ipa_search_path, "*.ipa")).max_by { |f| File.mtime(f) }
-    UI.user_error!("IPA not found in #{ipa_search_path}") if ipa_path.nil?
+    build_app(
+      workspace: File.join(WORKSPACE, "ios", "Runner.xcworkspace"),
+      scheme: "Runner",
+      export_method: "app-store",
+      export_options: File.join(WORKSPACE, "ios", "ExportOptions.plist")
+    )
 
     upload_to_testflight(
-      ipa: ipa_path,
       skip_waiting_for_build_processing: true,
       distribute_external: false,
       notify_external_testers: false,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -30,8 +30,11 @@ platform :ios do
     build_app(
       workspace: File.join(WORKSPACE, "ios", "Runner.xcworkspace"),
       scheme: "Runner",
+      configuration: "Release",
       export_method: "app-store",
-      export_options: File.join(WORKSPACE, "ios", "ExportOptions.plist")
+      export_options: File.join(WORKSPACE, "ios", "ExportOptions.plist"),
+      output_directory: File.join(WORKSPACE, "build", "ios", "ipa"),
+      clean: true
     )
 
     upload_to_testflight(


### PR DESCRIPTION
## 💡 개요
flutter build ipa로 빌드/서명/패키징을 Flutter가 모두 담당하던 방식에서
Flutter는 빌드만 담당하고 서명/아카이브/업로드는 Fastlane이 담당하도록 변경합니다.

## 🔗 관련 이슈
Closes #156

## 📃 작업내용
- `Fastfile`: flutter build ipa → flutter build ios --release --no-codesign 으로 변경
- `Fastfile`: build_app(gym)으로 archive 및 서명 처리 추가
- `cd-ios.yml`: 변경된 Fastfile에 맞게 워크플로우 수정

## 🔍 테스트 방법
- iOS CD 파이프라인 빌드 및 서명 정상 통과 확인
- TestFlight 업로드 성공 확인

## 🖼️ 스크린샷

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

## ✅ 체크리스트
- [ ] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [ ] 불필요한 코드가 없는지 확인했습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 기존 기능이 정상적으로 작동하는지 확인했습니다.