### PR TITLE
🔀 :: (#162) - iOS CI 키체인에서 Distribution 인증서를 찾지 못하는 오류를 수정하겠습니다

### DIFF
--- a/.github/workflows/cd-ios.yml
+++ b/.github/workflows/cd-ios.yml
@@ -121,6 +121,7 @@ jobs:
           # APP_STORE_CONNECT_ISSUER_ID는 민감하지 않아 GitHub Variables(vars)로 관리 권장
           # secrets 사용 시: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ vars.APP_STORE_CONNECT_ISSUER_ID }}
+          IOS_KEYCHAIN_PASSWORD: ${{ secrets.IOS_KEYCHAIN_PASSWORD }}
         run: bundle exec fastlane ios upload_testflight
 
       - name: Clean up keychain and provisioning profile

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,6 +28,7 @@ platform :ios do
     )
 
     keychain_path = File.join(ENV.fetch("RUNNER_TEMP", Dir.tmpdir), "app-signing.keychain-db")
+    keychain_password = ENV.fetch("IOS_KEYCHAIN_PASSWORD", "")
 
     build_app(
       workspace: File.join(WORKSPACE, "ios", "Runner.xcworkspace"),
@@ -37,7 +38,8 @@ platform :ios do
       export_options: File.join(WORKSPACE, "ios", "ExportOptions.plist"),
       output_directory: File.join(WORKSPACE, "build", "ios", "ipa"),
       clean: true,
-      xcargs: "OTHER_CODE_SIGN_FLAGS='--keychain #{keychain_path}'"
+      keychain_path: keychain_path,
+      keychain_password: keychain_password
     )
 
     upload_to_testflight(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -27,6 +27,8 @@ platform :ios do
       ].join(" ")
     )
 
+    keychain_path = File.join(ENV.fetch("RUNNER_TEMP", Dir.tmpdir), "app-signing.keychain-db")
+
     build_app(
       workspace: File.join(WORKSPACE, "ios", "Runner.xcworkspace"),
       scheme: "Runner",
@@ -34,7 +36,8 @@ platform :ios do
       export_method: "app-store",
       export_options: File.join(WORKSPACE, "ios", "ExportOptions.plist"),
       output_directory: File.join(WORKSPACE, "build", "ios", "ipa"),
-      clean: true
+      clean: true,
+      xcargs: "OTHER_CODE_SIGN_FLAGS='--keychain #{keychain_path}'"
     )
 
     upload_to_testflight(

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -648,7 +648,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Distribution";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;


### PR DESCRIPTION
## 💡 개요
flutter build ios --no-codesign은 성공하지만 build_app(xcodebuild archive) 단계에서
CI 커스텀 키체인을 자동으로 탐색하지 않아 iOS Distribution 인증서를 찾지 못해
빌드가 실패하는 문제를 수정합니다.

## 🔗 관련 이슈
Closes #162

## 📃 작업내용
- `Fastfile`: build_app의 xcargs에 OTHER_CODE_SIGN_FLAGS로 키체인 경로 명시적 전달
- `project.pbxproj`: Release 서명 ID 통일

## 🔍 테스트 방법
- iOS CD 파이프라인 build_app 단계 정상 통과 확인
- TestFlight 업로드 성공 확인

## 🖼️ 스크린샷


## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

## ✅ 체크리스트
- [ ] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [ ] 불필요한 코드가 없는지 확인했습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 기존 기능이 정상적으로 작동하는지 확인했습니다.