### PR TITLE
🔀 :: (#164) - iOS CI build_app 잘못된 keychain_path 옵션 오류를 수정하겠습니다

### DIFF
--- a/.github/workflows/cd-ios.yml
+++ b/.github/workflows/cd-ios.yml
@@ -121,7 +121,6 @@ jobs:
           # APP_STORE_CONNECT_ISSUER_ID는 민감하지 않아 GitHub Variables(vars)로 관리 권장
           # secrets 사용 시: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ vars.APP_STORE_CONNECT_ISSUER_ID }}
-          IOS_KEYCHAIN_PASSWORD: ${{ secrets.IOS_KEYCHAIN_PASSWORD }}
         run: bundle exec fastlane ios upload_testflight
 
       - name: Clean up keychain and provisioning profile

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -28,7 +28,6 @@ platform :ios do
     )
 
     keychain_path = File.join(ENV.fetch("RUNNER_TEMP", Dir.tmpdir), "app-signing.keychain-db")
-    keychain_password = ENV.fetch("IOS_KEYCHAIN_PASSWORD", "")
 
     build_app(
       workspace: File.join(WORKSPACE, "ios", "Runner.xcworkspace"),
@@ -38,8 +37,7 @@ platform :ios do
       export_options: File.join(WORKSPACE, "ios", "ExportOptions.plist"),
       output_directory: File.join(WORKSPACE, "build", "ios", "ipa"),
       clean: true,
-      keychain_path: keychain_path,
-      keychain_password: keychain_password
+      xcargs: "OTHER_CODE_SIGN_FLAGS='--keychain \"#{keychain_path}\"'"
     )
 
     upload_to_testflight(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -37,7 +37,9 @@ platform :ios do
       export_options: File.join(WORKSPACE, "ios", "ExportOptions.plist"),
       output_directory: File.join(WORKSPACE, "build", "ios", "ipa"),
       clean: true,
-      xcargs: "OTHER_CODE_SIGN_FLAGS='--keychain \"#{keychain_path}\"'"
+      xcargs: {
+        "OTHER_CODE_SIGN_FLAGS" => "$(inherited) --keychain \"#{keychain_path}\""
+      }
     )
 
     upload_to_testflight(


### PR DESCRIPTION
## 💡 개요
build_app에 존재하지 않는 keychain_path 옵션을 사용하여 빌드가 실패하는 문제를
xcargs의 OTHER_CODE_SIGN_FLAGS로 키체인 경로를 전달하는 방식으로 수정합니다.

## 🔗 관련 이슈
Closes #164

## 📃 작업내용
- `Fastfile`: build_app에서 keychain_path 옵션 제거
- `Fastfile`: xcargs에 OTHER_CODE_SIGN_FLAGS로 키체인 경로 명시적 전달로 변경
- `cd-ios.yml`: 관련 워크플로우 수정

## 🔍 테스트 방법
- iOS CD 파이프라인 build_app 단계 정상 통과 확인
- TestFlight 업로드 성공 확인

## 🖼️ 스크린샷


## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

## ✅ 체크리스트
- [ ] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [ ] 불필요한 코드가 없는지 확인했습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 기존 기능이 정상적으로 작동하는지 확인했습니다.