### PR TITLE
🔀 :: (#172) - iOS CI xcodebuild에 App Store Connect API 키 파일을 직접 생성하여 전달하겠습니다

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -12,50 +12,54 @@ platform :ios do
     api_key_path = File.join(Dir.tmpdir, "AuthKey_#{key_id}.p8")
     File.write(api_key_path, key_content)
 
-    app_store_connect_api_key(
-      key_id: key_id,
-      issuer_id: issuer_id,
-      key_content: key_content,
-      is_key_content_base64: false,
-      in_house: false
-    )
+    begin
+      app_store_connect_api_key(
+        key_id: key_id,
+        issuer_id: issuer_id,
+        key_content: key_content,
+        is_key_content_base64: false,
+        in_house: false
+      )
 
-    build_number = ENV.fetch("IOS_BUILD_NUMBER")
-    version_name = ENV.fetch("IOS_VERSION_NAME")
+      build_number = ENV.fetch("IOS_BUILD_NUMBER")
+      version_name = ENV.fetch("IOS_VERSION_NAME")
 
-    sh(
-      [
-        "fvm", "flutter", "build", "ios",
-        "--release",
-        "--no-codesign",
-        "--build-name=#{version_name}",
-        "--build-number=#{build_number}",
-        "--dart-define=APP_ENV=production"
-      ].join(" ")
-    )
+      sh(
+        [
+          "fvm", "flutter", "build", "ios",
+          "--release",
+          "--no-codesign",
+          "--build-name=#{version_name}",
+          "--build-number=#{build_number}",
+          "--dart-define=APP_ENV=production"
+        ].join(" ")
+      )
 
-    build_app(
-      workspace: File.join(WORKSPACE, "ios", "Runner.xcworkspace"),
-      scheme: "Runner",
-      configuration: "Release",
-      export_method: "app-store",
-      export_options: File.join(WORKSPACE, "ios", "ExportOptions.plist"),
-      output_directory: File.join(WORKSPACE, "build", "ios", "ipa"),
-      clean: true,
-      xcargs: [
-        "-allowProvisioningUpdates",
-        "-authenticationKeyPath #{api_key_path}",
-        "-authenticationKeyID #{key_id}",
-        "-authenticationKeyIssuerID #{issuer_id}"
-      ].join(" ")
-    )
+      build_app(
+        workspace: File.join(WORKSPACE, "ios", "Runner.xcworkspace"),
+        scheme: "Runner",
+        configuration: "Release",
+        export_method: "app-store",
+        export_options: File.join(WORKSPACE, "ios", "ExportOptions.plist"),
+        output_directory: File.join(WORKSPACE, "build", "ios", "ipa"),
+        clean: true,
+        xcargs: [
+          "-allowProvisioningUpdates",
+          "-authenticationKeyPath #{api_key_path}",
+          "-authenticationKeyID #{key_id}",
+          "-authenticationKeyIssuerID #{issuer_id}"
+        ].join(" ")
+      )
 
-    upload_to_testflight(
-      skip_waiting_for_build_processing: true,
-      distribute_external: false,
-      notify_external_testers: false,
-      changelog: ENV["TESTFLIGHT_CHANGELOG"]
-    )
+      upload_to_testflight(
+        skip_waiting_for_build_processing: true,
+        distribute_external: false,
+        notify_external_testers: false,
+        changelog: ENV["TESTFLIGHT_CHANGELOG"]
+      )
+    ensure
+      File.delete(api_key_path) if File.exist?(api_key_path)
+    end
   end
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -10,7 +10,7 @@ platform :ios do
     key_content = ENV.fetch("APP_STORE_CONNECT_API_KEY")
 
     api_key_path = File.join(Dir.tmpdir, "AuthKey_#{key_id}.p8")
-    File.write(api_key_path, key_content)
+    File.open(api_key_path, "w", 0o600) { |f| f.write(key_content) }
 
     begin
       app_store_connect_api_key(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,10 +5,17 @@ default_platform(:ios)
 platform :ios do
   desc "Build the iOS app and upload it to TestFlight without submitting for review"
   lane :upload_testflight do
-    api_key = app_store_connect_api_key(
-      key_id: ENV.fetch("APP_STORE_CONNECT_KEY_ID"),
-      issuer_id: ENV.fetch("APP_STORE_CONNECT_ISSUER_ID"),
-      key_content: ENV.fetch("APP_STORE_CONNECT_API_KEY"),
+    key_id = ENV.fetch("APP_STORE_CONNECT_KEY_ID")
+    issuer_id = ENV.fetch("APP_STORE_CONNECT_ISSUER_ID")
+    key_content = ENV.fetch("APP_STORE_CONNECT_API_KEY")
+
+    api_key_path = File.join(Dir.tmpdir, "AuthKey_#{key_id}.p8")
+    File.write(api_key_path, key_content)
+
+    app_store_connect_api_key(
+      key_id: key_id,
+      issuer_id: issuer_id,
+      key_content: key_content,
       is_key_content_base64: false,
       in_house: false
     )
@@ -37,9 +44,9 @@ platform :ios do
       clean: true,
       xcargs: [
         "-allowProvisioningUpdates",
-        "-authenticationKeyPath #{api_key[:key_filepath]}",
-        "-authenticationKeyID #{api_key[:key_id]}",
-        "-authenticationKeyIssuerID #{api_key[:issuer_id]}"
+        "-authenticationKeyPath #{api_key_path}",
+        "-authenticationKeyID #{key_id}",
+        "-authenticationKeyIssuerID #{issuer_id}"
       ].join(" ")
     )
 


### PR DESCRIPTION
## 💡 개요
api_key[:key_filepath]가 빈 값이라 xcodebuild에 API 키 경로를 전달하지 못해
프로비저닝 프로파일을 찾지 못하는 문제를
APP_STORE_CONNECT_API_KEY 환경변수로 .p8 파일을 직접 생성하여 해결합니다.

## 🔗 관련 이슈
Closes #172

## 📃 작업내용
- `Fastfile`: ENV["APP_STORE_CONNECT_API_KEY"] 내용을 임시 .p8 파일로 저장
- `Fastfile`: 해당 파일 경로를 xcargs의 -authenticationKeyPath에 전달
- `Fastfile`: 빌드 후 임시 .p8 파일 삭제 처리

## 🔍 테스트 방법
- iOS CD 파이프라인 build_app 단계 정상 통과 확인
- TestFlight 업로드 성공 확인

## 🖼️ 스크린샷
N/A

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

## ✅ 체크리스트
- [ ] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [ ] 불필요한 코드가 없는지 확인했습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 기존 기능이 정상적으로 작동하는지 확인했습니다.