### PR TITLE
🔀 :: (#174) - iOS CI App Store Connect Issuer ID 누락 오류를 수정하겠습니다

### DIFF
--- a/.github/workflows/cd-ios.yml
+++ b/.github/workflows/cd-ios.yml
@@ -120,7 +120,7 @@ jobs:
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
           # APP_STORE_CONNECT_ISSUER_ID는 민감하지 않아 GitHub Variables(vars)로 관리 권장
           # secrets 사용 시: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
-          APP_STORE_CONNECT_ISSUER_ID: ${{ vars.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         run: bundle exec fastlane ios upload_testflight
 
       - name: Clean up keychain and provisioning profile

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,6 +9,10 @@ platform :ios do
     issuer_id = ENV.fetch("APP_STORE_CONNECT_ISSUER_ID")
     key_content = ENV.fetch("APP_STORE_CONNECT_API_KEY")
 
+    UI.user_error!("APP_STORE_CONNECT_KEY_ID is empty") if key_id.empty?
+    UI.user_error!("APP_STORE_CONNECT_ISSUER_ID is empty") if issuer_id.empty?
+    UI.user_error!("APP_STORE_CONNECT_API_KEY is empty") if key_content.empty?
+
     api_key_path = File.join(Dir.tmpdir, "AuthKey_#{key_id}.p8")
     File.open(api_key_path, "w", 0o600) { |f| f.write(key_content) }
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,13 +5,13 @@ default_platform(:ios)
 platform :ios do
   desc "Build the iOS app and upload it to TestFlight without submitting for review"
   lane :upload_testflight do
-    key_id = ENV.fetch("APP_STORE_CONNECT_KEY_ID")
-    issuer_id = ENV.fetch("APP_STORE_CONNECT_ISSUER_ID")
-    key_content = ENV.fetch("APP_STORE_CONNECT_API_KEY")
+    key_id = ENV["APP_STORE_CONNECT_KEY_ID"].to_s
+    issuer_id = ENV["APP_STORE_CONNECT_ISSUER_ID"].to_s
+    key_content = ENV["APP_STORE_CONNECT_API_KEY"].to_s
 
-    UI.user_error!("APP_STORE_CONNECT_KEY_ID is empty") if key_id.empty?
-    UI.user_error!("APP_STORE_CONNECT_ISSUER_ID is empty") if issuer_id.empty?
-    UI.user_error!("APP_STORE_CONNECT_API_KEY is empty") if key_content.empty?
+    UI.user_error!("APP_STORE_CONNECT_KEY_ID is empty") if key_id.strip.empty?
+    UI.user_error!("APP_STORE_CONNECT_ISSUER_ID is empty") if issuer_id.strip.empty?
+    UI.user_error!("APP_STORE_CONNECT_API_KEY is empty") if key_content.strip.empty?
 
     api_key_path = File.join(Dir.tmpdir, "AuthKey_#{key_id}.p8")
     File.open(api_key_path, "w", 0o600) { |f| f.write(key_content) }


### PR DESCRIPTION
## 💡 개요
APP_STORE_CONNECT_ISSUER_ID가 누락되어 xcodebuild의 App Store Connect 인증이
실패하는 문제를 수정합니다.

## 🔗 관련 이슈
Closes #174

## 📃 작업내용
- `Fastfile`: App Store Connect 환경변수 빈 값 early validation 추가
- `cd-ios.yml`: vars.APP_STORE_CONNECT_ISSUER_ID → secrets.APP_STORE_CONNECT_ISSUER_ID로 변경

## 🔍 테스트 방법
- iOS CD 파이프라인 App Store Connect 인증 정상 통과 확인
- TestFlight 업로드 성공 확인

## 🖼️ 스크린샷


## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

## ✅ 체크리스트
- [ ] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [ ] 불필요한 코드가 없는지 확인했습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 기존 기능이 정상적으로 작동하는지 확인했습니다.