### PR TITLE
🔀 :: (#176) - iOS CI 서명 방식을 프로파일 UUID 추출 기반 Manual 서명으로 전환하겠습니다

### DIFF
--- a/.github/workflows/cd-ios.yml
+++ b/.github/workflows/cd-ios.yml
@@ -99,6 +99,9 @@ jobs:
           mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
           cp "$PROFILE_PATH" "$HOME/Library/MobileDevice/Provisioning Profiles"
 
+          PROFILE_UUID=$(security cms -D -i "$PROFILE_PATH" | plutil -extract UUID raw -)
+          echo "IOS_PROVISIONING_PROFILE_UUID=$PROFILE_UUID" >> "$GITHUB_ENV"
+
       - name: Resolve iOS version metadata
         run: |
           VERSION_LINE="$(grep '^version:' pubspec.yaml | head -n 1 | awk '{print $2}')"
@@ -118,8 +121,6 @@ jobs:
         env:
           APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
           APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
-          # APP_STORE_CONNECT_ISSUER_ID는 민감하지 않아 GitHub Variables(vars)로 관리 권장
-          # secrets 사용 시: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
           APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
         run: bundle exec fastlane ios upload_testflight
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -13,57 +13,54 @@ platform :ios do
     UI.user_error!("APP_STORE_CONNECT_ISSUER_ID is empty") if issuer_id.strip.empty?
     UI.user_error!("APP_STORE_CONNECT_API_KEY is empty") if key_content.strip.empty?
 
-    api_key_path = File.join(Dir.tmpdir, "AuthKey_#{key_id}.p8")
-    File.open(api_key_path, "w", 0o600) { |f| f.write(key_content) }
+    app_store_connect_api_key(
+      key_id: key_id,
+      issuer_id: issuer_id,
+      key_content: key_content,
+      is_key_content_base64: false,
+      in_house: false
+    )
 
-    begin
-      app_store_connect_api_key(
-        key_id: key_id,
-        issuer_id: issuer_id,
-        key_content: key_content,
-        is_key_content_base64: false,
-        in_house: false
-      )
+    build_number = ENV.fetch("IOS_BUILD_NUMBER")
+    version_name = ENV.fetch("IOS_VERSION_NAME")
+    profile_uuid = ENV.fetch("IOS_PROVISIONING_PROFILE_UUID")
 
-      build_number = ENV.fetch("IOS_BUILD_NUMBER")
-      version_name = ENV.fetch("IOS_VERSION_NAME")
+    sh(
+      [
+        "fvm", "flutter", "build", "ios",
+        "--release",
+        "--no-codesign",
+        "--build-name=#{version_name}",
+        "--build-number=#{build_number}",
+        "--dart-define=APP_ENV=production"
+      ].join(" ")
+    )
 
-      sh(
-        [
-          "fvm", "flutter", "build", "ios",
-          "--release",
-          "--no-codesign",
-          "--build-name=#{version_name}",
-          "--build-number=#{build_number}",
-          "--dart-define=APP_ENV=production"
-        ].join(" ")
-      )
+    build_app(
+      workspace: File.join(WORKSPACE, "ios", "Runner.xcworkspace"),
+      scheme: "Runner",
+      configuration: "Release",
+      export_options: {
+        method: "app-store",
+        teamID: "UB2797YAAH",
+        signingStyle: "manual",
+        signingCertificate: "Apple Distribution",
+        stripSwiftSymbols: true,
+        uploadBitcode: false,
+        uploadSymbols: true,
+        provisioningProfiles: { "com.washer.v2" => profile_uuid }
+      },
+      output_directory: File.join(WORKSPACE, "build", "ios", "ipa"),
+      clean: true,
+      xcargs: "CODE_SIGN_STYLE=Manual PROVISIONING_PROFILE=#{profile_uuid} CODE_SIGN_IDENTITY='Apple Distribution'"
+    )
 
-      build_app(
-        workspace: File.join(WORKSPACE, "ios", "Runner.xcworkspace"),
-        scheme: "Runner",
-        configuration: "Release",
-        export_method: "app-store",
-        export_options: File.join(WORKSPACE, "ios", "ExportOptions.plist"),
-        output_directory: File.join(WORKSPACE, "build", "ios", "ipa"),
-        clean: true,
-        xcargs: [
-          "-allowProvisioningUpdates",
-          "-authenticationKeyPath #{api_key_path}",
-          "-authenticationKeyID #{key_id}",
-          "-authenticationKeyIssuerID #{issuer_id}"
-        ].join(" ")
-      )
-
-      upload_to_testflight(
-        skip_waiting_for_build_processing: true,
-        distribute_external: false,
-        notify_external_testers: false,
-        changelog: ENV["TESTFLIGHT_CHANGELOG"]
-      )
-    ensure
-      File.delete(api_key_path) if File.exist?(api_key_path)
-    end
+    upload_to_testflight(
+      skip_waiting_for_build_processing: true,
+      distribute_external: false,
+      notify_external_testers: false,
+      changelog: ENV["TESTFLIGHT_CHANGELOG"]
+    )
   end
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -52,7 +52,7 @@ platform :ios do
       },
       output_directory: File.join(WORKSPACE, "build", "ios", "ipa"),
       clean: true,
-      xcargs: "CODE_SIGN_STYLE=Manual PROVISIONING_PROFILE=#{profile_uuid} CODE_SIGN_IDENTITY='Apple Distribution'"
+      xcargs: "CODE_SIGN_STYLE=Manual PROVISIONING_PROFILE=#{profile_uuid} CODE_SIGN_IDENTITY='Apple Distribution' DEVELOPMENT_TEAM=UB2797YAAH"
     )
 
     upload_to_testflight(


### PR DESCRIPTION
## 💡 개요
Automatic 서명 시 CI 환경에서 Apple ID 계정이 없어 401 오류가 반복 발생하여
프로비저닝 프로파일 UUID를 직접 추출하는 Manual 서명 방식으로 전환합니다.

## 🔗 관련 이슈
Closes #176

## 📃 작업내용
- `cd-ios.yml`: 프로비저닝 프로파일 설치 후 UUID 추출하여 IOS_PROVISIONING_PROFILE_UUID 환경변수로 전달
- `Fastfile`: .p8 파일 생성/삭제 제거, Manual 서명으로 전환
- `Fastfile`: app_store_connect_api_key는 upload_to_testflight에서만 사용하도록 변경

## 🔍 테스트 방법
- iOS CD 파이프라인 build_app 단계 401 오류 없이 정상 통과 확인
- TestFlight 업로드 성공 확인

## 🖼️ 스크린샷
N/A

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

## ✅ 체크리스트
- [ ] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [ ] 불필요한 코드가 없는지 확인했습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 기존 기능이 정상적으로 작동하는지 확인했습니다.