### PR TITLE
🔀 :: (#178) - iOS CI 전체 서명 환경 검증 코드를 추가하겠습니다

### DIFF
--- a/.github/workflows/cd-ios.yml
+++ b/.github/workflows/cd-ios.yml
@@ -92,13 +92,16 @@ jobs:
           security create-keychain -p "$IOS_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
           security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
           security unlock-keychain -p "$IOS_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security import "$CERTIFICATE_PATH" -P "$IOS_P12_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
-          security list-keychain -d user -s "$KEYCHAIN_PATH"
+          security import "$CERTIFICATE_PATH" -P "$IOS_P12_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH" || {
+            echo "::error::Failed to import certificate into keychain."
+            exit 1
+          }
+          security list-keychain -d user -s "$KEYCHAIN_PATH" $(security list-keychain -d user | tr -d '"')
           security set-key-partition-list -S apple-tool:,apple: -k "$IOS_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
           CERT_OUTPUT=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH")
           echo "$CERT_OUTPUT"
-          if echo "$CERT_OUTPUT" | grep -q "0 valid identities found"; then
+          if echo "$CERT_OUTPUT" | grep -qE "^\s+0 valid identities found"; then
             echo "::error::No valid signing certificate found in keychain."
             exit 1
           fi

--- a/.github/workflows/cd-ios.yml
+++ b/.github/workflows/cd-ios.yml
@@ -96,10 +96,25 @@ jobs:
           security list-keychain -d user -s "$KEYCHAIN_PATH"
           security set-key-partition-list -S apple-tool:,apple: -k "$IOS_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
 
+          CERT_OUTPUT=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH")
+          echo "$CERT_OUTPUT"
+          if echo "$CERT_OUTPUT" | grep -q "0 valid identities found"; then
+            echo "::error::No valid signing certificate found in keychain."
+            exit 1
+          fi
+
           mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
           cp "$PROFILE_PATH" "$HOME/Library/MobileDevice/Provisioning Profiles"
 
           PROFILE_UUID=$(security cms -D -i "$PROFILE_PATH" | plutil -extract UUID raw -)
+          if [ -z "$PROFILE_UUID" ]; then
+            echo "::error::Failed to extract UUID from provisioning profile."
+            exit 1
+          fi
+          if [ ! -f "$HOME/Library/MobileDevice/Provisioning Profiles/build_pp.mobileprovision" ]; then
+            echo "::error::Provisioning profile not found in Provisioning Profiles directory."
+            exit 1
+          fi
           echo "IOS_PROVISIONING_PROFILE_UUID=$PROFILE_UUID" >> "$GITHUB_ENV"
 
       - name: Resolve iOS version metadata
@@ -116,6 +131,24 @@ jobs:
           # pubspec의 build number 대신 run number를 사용해 TestFlight 중복을 방지
           echo "IOS_BUILD_NUMBER=${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
           echo "TESTFLIGHT_CHANGELOG=main branch build #${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
+
+      - name: Verify signing prerequisites
+        run: |
+          if [ -z "$IOS_PROVISIONING_PROFILE_UUID" ]; then
+            echo "::error::IOS_PROVISIONING_PROFILE_UUID is empty."
+            exit 1
+          fi
+          if [ -z "$IOS_VERSION_NAME" ]; then
+            echo "::error::IOS_VERSION_NAME is empty."
+            exit 1
+          fi
+          if [ -z "$IOS_BUILD_NUMBER" ]; then
+            echo "::error::IOS_BUILD_NUMBER is empty."
+            exit 1
+          fi
+          echo "Version: $IOS_VERSION_NAME"
+          echo "Build number: $IOS_BUILD_NUMBER"
+          echo "Profile UUID: $IOS_PROVISIONING_PROFILE_UUID"
 
       - name: Build & Upload to TestFlight
         env:

--- a/ios/ExportOptions.plist
+++ b/ios/ExportOptions.plist
@@ -16,5 +16,11 @@
     <false/>
     <key>uploadSymbols</key>
     <true/>
+    <!-- provisioningProfiles UUID는 CI에서 IOS_PROVISIONING_PROFILE_UUID 환경변수로 동적 주입됨 (Fastfile export_options Hash 참고) -->
+    <key>provisioningProfiles</key>
+    <dict>
+        <key>com.washer.v2</key>
+        <string>$(IOS_PROVISIONING_PROFILE_UUID)</string>
+    </dict>
 </dict>
 </plist>

--- a/ios/ExportOptions.plist
+++ b/ios/ExportOptions.plist
@@ -7,7 +7,9 @@
     <key>teamID</key>
     <string>UB2797YAAH</string>
     <key>signingStyle</key>
-    <string>automatic</string>
+    <string>manual</string>
+    <key>signingCertificate</key>
+    <string>Apple Distribution</string>
     <key>stripSwiftSymbols</key>
     <true/>
     <key>uploadBitcode</key>


### PR DESCRIPTION
## 💡 개요
iOS CI 빌드 시 서명 관련 오류가 발생해도 어느 단계에서 실패했는지
파악하기 어려워 디버깅이 오래 걸리는 문제를 해결합니다.
전체 서명 환경에 대한 검증 코드를 추가하여 오류 원인을 빠르게 파악합니다.

## 🔗 관련 이슈
Closes #178

## 📃 작업내용
- `cd-ios.yml`: 인증서 설치 후 커스텀 키체인 유효한 인증서 존재 여부 검증
- `cd-ios.yml`: 프로비저닝 프로파일 UUID 추출 성공 여부 검증
- `cd-ios.yml`: ~/Library/MobileDevice/Provisioning Profiles 파일 존재 여부 검증
- `cd-ios.yml`: IOS_PROVISIONING_PROFILE_UUID, IOS_VERSION_NAME, IOS_BUILD_NUMBER 환경변수 검증
- `cd-ios.yml`: 각 검증 실패 시 명확한 에러 메시지 출력 및 exit 1 처리

## 🔍 테스트 방법
- iOS CD 파이프라인 실행 후 검증 단계 로그 확인
- 각 검증 단계에서 정확한 에러 메시지 출력 확인

## 🖼️ 스크린샷
N/A

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

## ✅ 체크리스트
- [ ] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [ ] 불필요한 코드가 없는지 확인했습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 기존 기능이 정상적으로 작동하는지 확인했습니다.