### PR TITLE
🔀 :: (#183) - 타이포그래피 weight와 line-height를 Figma 스펙에 맞추겠습니다

### DIFF
--- a/lib/core/theme/typography.dart
+++ b/lib/core/theme/typography.dart
@@ -11,14 +11,12 @@ class WasherTypography {
   static TextStyle _suitBase({
     required double fontSize,
     required FontWeight fontWeight,
-    double height = 1,
     Color? color,
   }) {
     return TextStyle(
       fontFamily: _fontFamily,
       fontWeight: fontWeight,
       fontSize: fontSize.sp,
-      height: height,
       color: color ?? _defaultColor,
     );
   }
@@ -38,7 +36,7 @@ class WasherTypography {
   // Subtitle Styles
   static TextStyle subTitle1([Color? color]) => _suitBase(
     fontSize: 20,
-    fontWeight: FontWeight.normal,
+    fontWeight: FontWeight.w500,
     color: color,
   );
   static TextStyle subTitle2([Color? color]) => _suitBase(
@@ -48,7 +46,7 @@ class WasherTypography {
   );
   static TextStyle subTitle3([Color? color]) => _suitBase(
     fontSize: 18,
-    fontWeight: FontWeight.normal,
+    fontWeight: FontWeight.w500,
     color: color,
   );
   static TextStyle subTitle4([Color? color]) => _suitBase(
@@ -60,12 +58,12 @@ class WasherTypography {
   // Body Styles
   static TextStyle body1([Color? color]) => _suitBase(
     fontSize: 16,
-    fontWeight: FontWeight.normal,
+    fontWeight: FontWeight.w500,
     color: color,
   );
   static TextStyle body2([Color? color]) => _suitBase(
     fontSize: 15,
-    fontWeight: FontWeight.normal,
+    fontWeight: FontWeight.w500,
     color: color,
   );
   static TextStyle body3([Color? color]) => _suitBase(
@@ -75,14 +73,14 @@ class WasherTypography {
   );
   static TextStyle body4([Color? color]) => _suitBase(
     fontSize: 14,
-    fontWeight: FontWeight.normal,
+    fontWeight: FontWeight.w500,
     color: color,
   );
 
   // Caption Style
   static TextStyle caption([Color? color]) => _suitBase(
     fontSize: 12,
-    fontWeight: FontWeight.normal,
+    fontWeight: FontWeight.w500,
     color: color,
   );
 }

--- a/lib/features/home/presentation/widgets/home_machine_section_widget.dart
+++ b/lib/features/home/presentation/widgets/home_machine_section_widget.dart
@@ -135,7 +135,7 @@ class _SectionTitle extends StatelessWidget {
   Widget build(BuildContext context) {
     return Text(
       title,
-      style: WasherTypography.h2(WasherColor.baseGray700),
+      style: WasherTypography.subTitle1(WasherColor.baseGray700),
     );
   }
 }

--- a/lib/features/reservation/presentation/widgets/reservation_title_widget.dart
+++ b/lib/features/reservation/presentation/widgets/reservation_title_widget.dart
@@ -12,7 +12,7 @@ class ReservationTitleWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Text(
       '${laundryMachineType.text}기 예약 현황',
-      style: WasherTypography.h2(),
+      style: WasherTypography.subTitle1(),
     );
   }
 }


### PR DESCRIPTION
## 💡 개요
홈/예약/알림 화면 텍스트가 [Figma 타이포 스펙](https://www.figma.com/design/YxAcgsJjCQZaihE0KPc6hQ/washer-%F0%9F%A7%BA?node-id=2448-654&m=dev)과 weight·줄간격이 어긋나 있어, `typography.dart`의 weight·line-height와 두 곳의 토큰 선택을 정정합니다.

## 🔗 관련 이슈
Close #183

## 📃 작업내용
- `_suitBase`의 `height: 1` 디폴트를 제거하여 폰트 자연 leading(Auto)을 따르도록 변경
- `subTitle1`, `subTitle3`, `body1`, `body2`, `body4`, `caption`의 weight를 `FontWeight.w500`(Medium)로 정정
- `home_machine_section_widget.dart` `_SectionTitle`: `h2(SemiBold 20) → subTitle1(Medium 20)` 토큰 교체
- `reservation_title_widget.dart`: `h2 → subTitle1` 토큰 교체

## 🔍 테스트 방법
- 홈 화면에서 `세탁기 예약 현황` / `건조기 예약 현황` 섹션 타이틀의 weight·크기가 Figma와 동일한지 확인
- 예약 상세 화면(`/washer`, `/dryer`) 헤더, `Dryer-3F-L1` 등 기기명, 상태 뱃지, 보조 텍스트의 weight·줄간격 확인
- 알림 화면 카드 타이틀/시각/본문의 weight 확인
- 일치 항목(`h1`, `h2`, `subTitle2`, `subTitle4`, `body3`)은 변경되지 않았는지 회귀 확인

## 🖼️ 스크린샷
N/A

## 🙋‍♂️ 질문사항
- 컬러 토큰 네이밍이 Figma와 한 단계 어긋나는 이슈(`baseGray700`=`#5F5F5F` vs Figma `Gray/g 700`=`#494949`)와, 예약 상세 화면의 층 칩 사이즈(`body4` 14 → Figma 18), `배치도 보기` 사이즈/컬러 차이는 본 PR 범위에서 제외하고 별도 이슈로 분리 예정입니다.
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

## ✅ 체크리스트
- [ ] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [x] 불필요한 코드가 없는지 확인했습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [ ] 기존 기능이 정상적으로 작동하는지 확인했습니다.