### PR TITLE
🔀 :: (#185) - 남은 Figma 스펙 차이(컬러 호출부·사이즈·배경·카피)를 정렬하겠습니다

### DIFF
--- a/lib/core/theme/color.dart
+++ b/lib/core/theme/color.dart
@@ -42,5 +42,5 @@ class WasherColor {
   static const negative = errorColor;
 
   // background color
-  static const backgroundColor = Color(0xFFF4F4F9);
+  static const backgroundColor = Color(0xFFF4F5F9);
 }

--- a/lib/features/alarm/presentation/widgets/alarm_list_widget.dart
+++ b/lib/features/alarm/presentation/widgets/alarm_list_widget.dart
@@ -32,7 +32,7 @@ class AlarmListWidget extends ConsumerWidget {
         Text(
           '알림',
           style: WasherTypography.subTitle3(
-            WasherColor.baseGray700,
+            WasherColor.baseGray800,
           ),
         ),
         AppGap.v16,
@@ -54,7 +54,7 @@ class _AlarmListBody extends ConsumerWidget {
         return Center(
           child: Text(
             '홈 화면을 새로고침하면 알림이 갱신됩니다.',
-            style: WasherTypography.body1(WasherColor.baseGray400),
+            style: WasherTypography.body1(WasherColor.baseGray500),
             textAlign: TextAlign.center,
           ),
         );
@@ -67,7 +67,7 @@ class _AlarmListBody extends ConsumerWidget {
             children: [
               Text(
                 state.errorMessage ?? '알람을 불러오지 못했습니다.',
-                style: WasherTypography.body1(WasherColor.baseGray400),
+                style: WasherTypography.body1(WasherColor.baseGray500),
                 textAlign: TextAlign.center,
               ),
               AppGap.v12,
@@ -89,7 +89,7 @@ class _AlarmListBody extends ConsumerWidget {
           return Center(
             child: Text(
               '알림이 없습니다!',
-              style: WasherTypography.body1(WasherColor.baseGray400),
+              style: WasherTypography.body1(WasherColor.baseGray500),
             ),
           );
         }

--- a/lib/features/alarm/presentation/widgets/local_widgets/alarm_date_divider.dart
+++ b/lib/features/alarm/presentation/widgets/local_widgets/alarm_date_divider.dart
@@ -11,21 +11,21 @@ class _DateDivider extends StatelessWidget {
     return Row(
       children: [
         const Expanded(
-          child: Divider(color: WasherColor.baseGray300, thickness: 1),
+          child: Divider(color: WasherColor.baseGray500, thickness: 1),
         ),
         Flexible(
           child: Padding(
             padding: const EdgeInsets.symmetric(horizontal: 12),
             child: Text(
               date,
-              style: WasherTypography.body4(WasherColor.baseGray300),
+              style: WasherTypography.body4(WasherColor.baseGray500),
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
             ),
           ),
         ),
         const Expanded(
-          child: Divider(color: WasherColor.baseGray300, thickness: 1),
+          child: Divider(color: WasherColor.baseGray500, thickness: 1),
         ),
       ],
     );

--- a/lib/features/alarm/presentation/widgets/machine_state_widget.dart
+++ b/lib/features/alarm/presentation/widgets/machine_state_widget.dart
@@ -77,7 +77,7 @@ class _TitleWithStatus extends StatelessWidget {
           child: Text(
             _titleFor(laundryStatus),
             style: WasherTypography.subTitle3(
-              WasherColor.baseGray700,
+              WasherColor.baseGray800,
             ),
             maxLines: 1,
             overflow: TextOverflow.ellipsis,
@@ -139,7 +139,7 @@ class _DateText extends StatelessWidget {
     return Text(
       date,
       style: WasherTypography.body4(
-        WasherColor.baseGray300,
+        WasherColor.baseGray500,
       ),
     );
   }
@@ -158,7 +158,7 @@ class _DescriptionText extends StatelessWidget {
     return Text(
       descriptionText,
       style: WasherTypography.body1(
-        WasherColor.baseGray400,
+        WasherColor.baseGray500,
       ),
     );
   }

--- a/lib/features/home/presentation/widgets/home_machine_section_widget.dart
+++ b/lib/features/home/presentation/widgets/home_machine_section_widget.dart
@@ -101,8 +101,8 @@ class HomeMachineSectionWidget extends StatelessWidget {
             padding: EdgeInsets.symmetric(vertical: AppSpacing.v16),
             child: Center(
               child: Text(
-                '기기 정보가 없습니다.',
-                style: WasherTypography.body1(WasherColor.baseGray300),
+                '현재 예약하거나 사용중인 기기가 없습니다.',
+                style: WasherTypography.body1(WasherColor.baseGray500),
               ),
             ),
           )
@@ -135,7 +135,7 @@ class _SectionTitle extends StatelessWidget {
   Widget build(BuildContext context) {
     return Text(
       title,
-      style: WasherTypography.subTitle1(WasherColor.baseGray700),
+      style: WasherTypography.subTitle1(WasherColor.baseGray800),
     );
   }
 }
@@ -155,13 +155,13 @@ class _ViewAll extends StatelessWidget {
         children: [
           Text(
             '전체보기',
-            style: WasherTypography.body2(WasherColor.baseGray300),
+            style: WasherTypography.body2(WasherColor.baseGray500),
           ),
           AppGap.h4,
           const WasherIcon(
             type: WasherIconType.back,
             size: 16,
-            color: WasherColor.baseGray300,
+            color: WasherColor.baseGray500,
           ),
         ],
       ),
@@ -214,8 +214,8 @@ class HomeMachineSectionSliver extends StatelessWidget {
               padding: EdgeInsets.symmetric(vertical: AppSpacing.v16),
               child: Center(
                 child: Text(
-                  '기기 정보가 없습니다.',
-                  style: WasherTypography.body1(WasherColor.baseGray300),
+                  '현재 예약하거나 사용중인 기기가 없습니다.',
+                  style: WasherTypography.body1(WasherColor.baseGray500),
                 ),
               ),
             ),
@@ -292,8 +292,8 @@ class _StatusItem extends StatelessWidget {
                 machine.name,
                 style: WasherTypography.body1(
                   isAvailable
-                      ? WasherColor.baseGray700
-                      : WasherColor.baseGray300,
+                      ? WasherColor.baseGray800
+                      : WasherColor.baseGray500,
                 ),
               ),
             ],

--- a/lib/features/reservation/presentation/widgets/reservation_section_widget.dart
+++ b/lib/features/reservation/presentation/widgets/reservation_section_widget.dart
@@ -398,10 +398,10 @@ class _FloorSelectorRow extends StatelessWidget {
                       ),
                       child: Text(
                         '$floor층',
-                        style: WasherTypography.body4(
+                        style: WasherTypography.subTitle3(
                           selectedFloor == floor
                               ? Colors.white
-                              : WasherColor.baseGray600,
+                              : WasherColor.baseGray800,
                         ),
                       ),
                     ),
@@ -416,13 +416,13 @@ class _FloorSelectorRow extends StatelessWidget {
             children: [
               Text(
                 '배치도 보기',
-                style: WasherTypography.body4(WasherColor.baseGray300),
+                style: WasherTypography.body2(WasherColor.baseGray500),
               ),
               AppGap.h4,
               const WasherIcon(
                 type: WasherIconType.map,
                 size: 20,
-                color: WasherColor.baseGray300,
+                color: WasherColor.baseGray500,
               ),
             ],
           ),

--- a/lib/features/reservation/presentation/widgets/reservation_title_widget.dart
+++ b/lib/features/reservation/presentation/widgets/reservation_title_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:washer/core/enums/laundry_machine_type.dart';
+import 'package:washer/core/theme/color.dart';
 import 'package:washer/core/theme/typography.dart';
 
 /// 예약 내역 제목 위젯 (세탁기/건조기 목록 제메이)
@@ -12,7 +13,7 @@ class ReservationTitleWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Text(
       '${laundryMachineType.text}기 예약 현황',
-      style: WasherTypography.subTitle1(),
+      style: WasherTypography.subTitle1(WasherColor.baseGray800),
     );
   }
 }

--- a/lib/features/reservation/presentation/widgets/reservation_widget.dart
+++ b/lib/features/reservation/presentation/widgets/reservation_widget.dart
@@ -80,7 +80,7 @@ class ReservationWidget extends StatelessWidget {
                       child: Text(
                         machineName,
                         style: WasherTypography.subTitle3(
-                          WasherColor.baseGray700,
+                          WasherColor.baseGray800,
                         ),
                         maxLines: 1,
                         overflow: TextOverflow.ellipsis,
@@ -222,24 +222,24 @@ class _InUseBottom extends ConsumerWidget {
         children: [
           Text(
             '${laundryMachineType.text} 사용 중',
-            style: WasherTypography.body2(WasherColor.baseGray400),
+            style: WasherTypography.body2(WasherColor.baseGray500),
           ),
           AppGap.v4,
           Text(
             '분석중',
-            style: WasherTypography.body2(WasherColor.baseGray400),
+            style: WasherTypography.body2(WasherColor.baseGray500),
           ),
           AppGap.v4,
           if (room != null)
             Text(
               '사용 호실: ${RoomFormatter.formatRoom(room)}',
-              style: WasherTypography.body2(WasherColor.baseGray400),
+              style: WasherTypography.body2(WasherColor.baseGray500),
             ),
           if (activeUserLabel != null) ...[
             AppGap.v4,
             Text(
               '$activeUserLabel 이용중...',
-              style: WasherTypography.body2(WasherColor.baseGray400),
+              style: WasherTypography.body2(WasherColor.baseGray500),
             ),
           ],
         ],
@@ -259,24 +259,24 @@ class _InUseBottom extends ConsumerWidget {
       children: [
         Text(
           '${laundryMachineType.text} 사용 중',
-          style: WasherTypography.body2(WasherColor.baseGray400),
+          style: WasherTypography.body2(WasherColor.baseGray500),
         ),
         AppGap.v4,
         Text(
           '남은 ${laundryMachineType == LaundryMachineType.washer ? '세탁' : '건조'} 시간: $countdown',
-          style: WasherTypography.body2(WasherColor.baseGray400),
+          style: WasherTypography.body2(WasherColor.baseGray500),
         ),
         AppGap.v4,
         if (room != null)
           Text(
             '사용 호실: ${RoomFormatter.formatRoom(room)}',
-            style: WasherTypography.body2(WasherColor.baseGray400),
+            style: WasherTypography.body2(WasherColor.baseGray500),
           ),
         if (activeUserLabel != null) ...[
           AppGap.v4,
           Text(
             '$activeUserLabel 이용중...',
-            style: WasherTypography.body2(WasherColor.baseGray400),
+            style: WasherTypography.body2(WasherColor.baseGray500),
           ),
         ],
       ],
@@ -308,7 +308,7 @@ class _AvailableBottom extends StatelessWidget {
       children: [
         Text(
           '미사용 중',
-          style: WasherTypography.body2(WasherColor.baseGray400),
+          style: WasherTypography.body2(WasherColor.baseGray500),
         ),
         AppGap.v12,
         Row(


### PR DESCRIPTION
## 💡 개요
#183 이후 남아 있던 Figma 스펙 불일치(컬러 호출부·예약 화면 사이즈·배경색·홈 빈 상태 카피)를 정렬합니다. 컬러 토큰 자체의 rename은 영향 범위가 커서 본 PR에서 제외하고, **호출부에서 올바른 토큰을 쓰도록** 교체했습니다.

## 🔗 관련 이슈
Close #185

## 📃 작업내용
### 배경색
- `WasherColor.backgroundColor`: `#F4F4F9` → `#F4F5F9`

### 컬러 호출부 정정 (Figma `Gray/g 700` `#494949` 대상)
- `home_machine_section_widget.dart` 섹션 타이틀·활성 기기명: `baseGray700` → `baseGray800`
- `reservation_title_widget.dart` 헤더: 기본 컬러 대신 `baseGray800` 명시
- `reservation_widget.dart` 기기명: `baseGray700` → `baseGray800`
- `alarm_list_widget.dart` `알림` 타이틀: `baseGray700` → `baseGray800`
- `machine_state_widget.dart` 카드 타이틀: `baseGray700` → `baseGray800`

### 컬러 호출부 정정 (Figma `Gray/g 400` `#969696` 대상)
- `home_machine_section_widget.dart` 전체보기·비활성 기기명·빈 상태: `baseGray300` → `baseGray500`
- `reservation_section_widget.dart` `배치도 보기`: `baseGray300` → `baseGray500`
- `reservation_widget.dart` `사용 중`·`남은 시간`·`사용 호실`·`이용중...`·`미사용 중`·`분석중`: `baseGray400` → `baseGray500`
- `alarm_list_widget.dart` empty/error/no-alarm 메시지: `baseGray400` → `baseGray500`
- `alarm_date_divider.dart` 날짜 텍스트·디바이더: `baseGray300` → `baseGray500`
- `machine_state_widget.dart` 시각(`baseGray300`)·본문(`baseGray400`): → `baseGray500`

### 사이즈 미스매치 (예약 상세)
- 층 선택 칩 `$floor층`: 토큰 `body4`(14) → `subTitle3`(18), 비활성 컬러 `baseGray600` → `baseGray800`
- `배치도 보기`: 토큰 `body4`(14) → `body2`(15)

### 카피 (홈)
- `'기기 정보가 없습니다.'` → `'현재 예약하거나 사용중인 기기가 없습니다.'` (Box·Sliver 두 곳)

## 🔍 테스트 방법
- 홈 화면: 섹션 타이틀·기기명(활성/비활성)·전체보기·빈 상태 텍스트 색감 확인
- 예약 상세 화면: 층 칩 사이즈·미선택 컬러, `배치도 보기` 사이즈, 기기명·뱃지·보조 텍스트 색감 확인
- 알림 화면: 페이지 타이틀, 날짜 구분선/시각, 카드 타이틀/본문, 빈/에러 상태 색감 확인
- 전체 화면 배경색이 미세하게 푸른빛으로 보정되는지 확인

## 🖼️ 스크린샷
N/A

## 🙋‍♂️ 질문사항
- 컬러 토큰 네이밍을 Figma와 1:1로 맞추는 rename(`baseGray800 → baseGray700` 등)은 본 PR 범위에서 제외, 별도 이슈 권장.
- 본 PR은 검토 완료된 4개 노드(타이포 스펙·홈·예약 상세·알림) 기준이며, 다른 화면(설정·이력·신고 등)에 동일 패턴이 있다면 후속 PR로 정렬 권장.
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

## ✅ 체크리스트
- [ ] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [x] 불필요한 코드가 없는지 확인했습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [ ] 기존 기능이 정상적으로 작동하는지 확인했습니다.