### PR TITLE
🔀 :: (#187) - 5XX호 사용자가 빈 기기 응답(451) 시 에러 화면 대신 빈 상태로 표시되도록 하겠습니다

### DIFF
--- a/lib/core/utils/room_formatter.dart
+++ b/lib/core/utils/room_formatter.dart
@@ -1,6 +1,8 @@
 class RoomFormatter {
   const RoomFormatter._();
 
+  static const Set<int> supportedFloors = {3, 4, 5};
+
   static String formatRoomNumber(String? roomNumber) {
     final formattedRoom = formatRoom(roomNumber);
     if (formattedRoom == null || formattedRoom.isEmpty) {
@@ -25,5 +27,33 @@ class RoomFormatter {
     }
 
     return '$normalized호';
+  }
+
+  static int? floorFromRoomNumber(String? roomNumber) {
+    if (roomNumber == null) {
+      return null;
+    }
+
+    final normalized = roomNumber.trim();
+    if (normalized.isEmpty) {
+      return null;
+    }
+
+    final digitsOnly = normalized.replaceAll(RegExp(r'[^0-9]'), '');
+    if (digitsOnly.isEmpty) {
+      return null;
+    }
+
+    final int? floor;
+    if (digitsOnly.length < 3) {
+      floor = int.tryParse(digitsOnly);
+    } else {
+      floor = int.tryParse(digitsOnly.substring(0, digitsOnly.length - 2));
+    }
+
+    if (floor == null || !supportedFloors.contains(floor)) {
+      return null;
+    }
+    return floor;
   }
 }

--- a/lib/core/utils/room_formatter.dart
+++ b/lib/core/utils/room_formatter.dart
@@ -39,10 +39,11 @@ class RoomFormatter {
       return null;
     }
 
-    final digitsOnly = normalized.replaceAll(RegExp(r'[^0-9]'), '');
-    if (digitsOnly.isEmpty) {
+    final match = RegExp(r'\d+').firstMatch(normalized);
+    if (match == null) {
       return null;
     }
+    final digitsOnly = match.group(0)!;
 
     final int? floor;
     if (digitsOnly.length < 3) {

--- a/lib/features/home/presentation/widgets/home_body_widget.dart
+++ b/lib/features/home/presentation/widgets/home_body_widget.dart
@@ -4,6 +4,7 @@ import 'package:washer/core/enums/laundry_machine_type.dart';
 import 'package:washer/core/theme/color.dart';
 import 'package:washer/core/theme/spacing.dart';
 import 'package:washer/core/theme/typography.dart';
+import 'package:washer/core/utils/room_formatter.dart';
 import 'package:washer/features/alarm/presentation/providers/alarm_provider.dart';
 import 'package:washer/features/home/presentation/widgets/home_machine_section_widget.dart';
 import 'package:washer/features/home/presentation/widgets/home_my_reservation_widget.dart';
@@ -23,28 +24,6 @@ class _HomeBodyWidgetState extends ConsumerState<HomeBodyWidget>
 
   AppLifecycleState? _lastLifecycleState;
   DateTime? _lastResumeRefreshAt;
-
-  int? _targetFloorFromRoomNumber(String? roomNumber) {
-    if (roomNumber == null) {
-      return null;
-    }
-
-    final normalized = roomNumber.trim();
-    if (normalized.isEmpty) {
-      return null;
-    }
-
-    final digitsOnly = normalized.replaceAll(RegExp(r'[^0-9]'), '');
-    if (digitsOnly.length < 3) {
-      final floor = int.tryParse(digitsOnly);
-      if (floor != null && (floor == 3 || floor == 4)) {
-        return floor;
-      }
-      return null;
-    }
-
-    return int.tryParse(digitsOnly.substring(0, digitsOnly.length - 2));
-  }
 
   @override
   void initState() {
@@ -115,7 +94,7 @@ class _HomeBodyWidgetState extends ConsumerState<HomeBodyWidget>
                   ? reservations.first.userRoomNumber
                   : null,
             );
-        final targetFloor = _targetFloorFromRoomNumber(roomNumber);
+        final targetFloor = RoomFormatter.floorFromRoomNumber(roomNumber);
         final visibleMachines = targetFloor == null
             ? data.machines
             : data.machines

--- a/lib/features/reservation/data/data_sources/remote/reservation_status_remote_data_source.dart
+++ b/lib/features/reservation/data/data_sources/remote/reservation_status_remote_data_source.dart
@@ -31,10 +31,17 @@ class HomeRemoteDataSourceImpl implements HomeRemoteDataSource {
 
   @override
   Future<MachineStatusResponse> getMachineStatus() async {
-    final response = await _api.getMachineStatus();
-    final data = extractDataMap(castJsonMap(response.data));
+    try {
+      final response = await _api.getMachineStatus();
+      final data = extractDataMap(castJsonMap(response.data));
 
-    return MachineStatusResponse.fromJson(data);
+      return MachineStatusResponse.fromJson(data);
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 451) {
+        return const MachineStatusResponse(machines: [], totalCount: 0);
+      }
+      rethrow;
+    }
   }
 
   @override
@@ -56,7 +63,8 @@ class HomeRemoteDataSourceImpl implements HomeRemoteDataSource {
           .map((item) => ActiveReservationModel.fromJson(castJsonMap(item)))
           .toList(growable: false);
     } on DioException catch (e) {
-      if (e.response?.statusCode == 404 || e.response?.statusCode == 204) {
+      final statusCode = e.response?.statusCode;
+      if (statusCode == 404 || statusCode == 204 || statusCode == 451) {
         return const [];
       }
       rethrow;

--- a/lib/features/reservation/presentation/widgets/reservation_section_widget.dart
+++ b/lib/features/reservation/presentation/widgets/reservation_section_widget.dart
@@ -228,11 +228,7 @@ class _ReservationSectionWidgetState
             .watch(activeReservationProvider)
             .whenOrNull(data: (reservations) => reservations) ??
         const <ActiveReservationModel>[];
-    final myUser = ref
-        .watch(myUserProvider)
-        .whenOrNull(
-          data: (user) => user,
-        );
+    final myUser = ref.watch(myUserProvider).value;
     final myUserId = myUser?.id;
     final userFloor = RoomFormatter.floorFromRoomNumber(myUser?.roomNumber);
 

--- a/lib/features/reservation/presentation/widgets/reservation_section_widget.dart
+++ b/lib/features/reservation/presentation/widgets/reservation_section_widget.dart
@@ -12,6 +12,7 @@ import 'package:washer/core/theme/icon.dart';
 import 'package:washer/core/theme/spacing.dart';
 import 'package:washer/core/theme/typography.dart';
 import 'package:washer/core/utils/app_logger.dart';
+import 'package:washer/core/utils/room_formatter.dart';
 import 'package:washer/features/reservation/data/models/local/active_reservation_model.dart';
 import 'package:washer/features/reservation/data/models/local/laundry_machine_model.dart';
 import 'package:washer/features/reservation/presentation/providers/reservation_status_provider.dart';
@@ -54,9 +55,15 @@ class _ReservationSectionWidgetState
         .toList(growable: false);
   }
 
-  List<int> _floorsFrom(List<MachineModel> machines) {
-    return machines.map((m) => m.floorNumber).whereType<int>().toSet().toList()
-      ..sort();
+  List<int> _floorsFrom(List<MachineModel> machines, int? userFloor) {
+    final floors = machines
+        .map((m) => m.floorNumber)
+        .whereType<int>()
+        .toSet();
+    if (userFloor != null) {
+      floors.add(userFloor);
+    }
+    return floors.toList()..sort();
   }
 
   ReservationState _toReservationState(
@@ -221,11 +228,13 @@ class _ReservationSectionWidgetState
             .watch(activeReservationProvider)
             .whenOrNull(data: (reservations) => reservations) ??
         const <ActiveReservationModel>[];
-    final myUserId = ref
+    final myUser = ref
         .watch(myUserProvider)
         .whenOrNull(
-          data: (user) => user?.id,
+          data: (user) => user,
         );
+    final myUserId = myUser?.id;
+    final userFloor = RoomFormatter.floorFromRoomNumber(myUser?.roomNumber);
 
     return machineAsync.when(
       loading: () => const Center(child: CircularProgressIndicator()),
@@ -248,7 +257,7 @@ class _ReservationSectionWidgetState
       ),
       data: (data) {
         final typedMachines = _machinesForType(data.machines);
-        final floors = _floorsFrom(typedMachines);
+        final floors = _floorsFrom(typedMachines, userFloor);
         final currentFloor =
             _selectedFloor ?? (floors.isNotEmpty ? floors.first : 0);
         final items = _buildItems(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -117,10 +117,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -552,14 +552,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.2"
   json_annotation:
     dependency: "direct main"
     description:
@@ -628,18 +620,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -961,26 +953,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.3"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.12"
+    version: "0.6.16"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+5
+version: 1.0.0+6
 
 environment:
   sdk: ^3.9.2


### PR DESCRIPTION
## Summary

- 서버가 5XX호 사용자에게 반환하는 `GET /api/v2/machines/status` **HTTP 451**을 데이터 소스 레이어에서 빈 응답으로 변환해, 홈 화면이 `_HomeErrorView`(`기기 현황을 불러오지 못했습니다.`) 대신 정상적인 빈 상태를 보여주도록 한다.
- 예약 화면(`ReservationSectionWidget`)이 머신 목록뿐 아니라 **사용자 본인의 층**도 칩 후보로 사용하도록 변경, 5XX호 사용자에게 `5층` 칩이 항상 노출되도록 한다 (선택 시 기존 `'표시할 기기가 없습니다.'`).
- 룸번호 → 층 추출 로직을 `RoomFormatter.floorFromRoomNumber`로 공용화하고 홈 화면의 private 헬퍼를 치환 (3·4·5층 화이트리스트).
- Android 빌드 번호 `1.0.0+5` → `1.0.0+6`.

resolves #187

## 변경 파일
- `lib/features/reservation/data/data_sources/remote/reservation_status_remote_data_source.dart` — `getMachineStatus`/`getActiveReservations`에 451 분기 추가
- `lib/core/utils/room_formatter.dart` — `floorFromRoomNumber()` 신설
- `lib/features/home/presentation/widgets/home_body_widget.dart` — 공용 유틸 호출로 치환
- `lib/features/reservation/presentation/widgets/reservation_section_widget.dart` — `myUserProvider.roomNumber` 기반 5층 칩 머지
- `pubspec.yaml` / `pubspec.lock`

## Test plan
- [ ] 5XX호 계정으로 로그인 → 홈에서 `'현재 예약하거나 사용중인 기기가 없습니다.'` 노출 확인 (에러 뷰 X)
- [ ] 5XX호 계정 → 예약 → 세탁기 탭: 층 칩에 `5층`만 보이고 선택 시 `'표시할 기기가 없습니다.'`
- [ ] 5XX호 계정 → 예약 → 건조기 탭: 동일하게 5층 칩 + 빈 상태
- [ ] 3XX/4XX호 계정 회귀: 기존처럼 자기 층 기기만 표시, 칩 동작 정상
- [ ] 룸번호 NULL/공백 사용자: 기존처럼 전 층 노출
- [ ] `flutter analyze` 0건
- [ ] `flutter test test/features/reservation/reservation_test.dart` 11/11 통과