### PR TITLE
🔀 :: (#189) - JWT 리프레시 토큰 갱신 실패 버그를 수정하겠습니다

### DIFF
--- a/lib/core/network/auth_interceptor.dart
+++ b/lib/core/network/auth_interceptor.dart
@@ -211,6 +211,13 @@ class AuthInterceptor extends Interceptor {
     onLogout?.call();
   }
 
+  /// 스토리지 토큰은 유지하고 메모리 캐시만 초기화
+  void clearInMemoryCache() {
+    _cachedAccessToken = null;
+    _refreshFuture = null;
+  }
+
+  /// 로그아웃 시 메모리 캐시 + 스토리지 토큰 모두 삭제
   Future<void> clearCache() async {
     _cachedAccessToken = null;
     _refreshFuture = null;

--- a/lib/core/network/auth_interceptor.dart
+++ b/lib/core/network/auth_interceptor.dart
@@ -139,11 +139,7 @@ class AuthInterceptor extends Interceptor {
     final refreshEndpoint = _environment.refreshTokenEndpoint;
     final response = await _refreshDio.post(
       refreshEndpoint,
-      options: Options(
-        headers: {
-          'Authorization': 'Bearer $refreshToken',
-        },
-      ),
+      data: {'refreshToken': refreshToken},
     );
 
     final responseData = response.data;

--- a/lib/core/network/dio_client.dart
+++ b/lib/core/network/dio_client.dart
@@ -55,6 +55,8 @@ class DioClient {
 
   Dio get dio => _dio;
 
+  void clearInMemoryCache() => _authInterceptor.clearInMemoryCache();
+
   Future<void> clearAuthCache() => _authInterceptor.clearCache();
 }
 

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -85,6 +85,7 @@ class AuthRepositoryImpl implements AuthRepository {
     await Future.wait([
       _storage.write(key: 'access_token', value: response.accessToken),
       _storage.write(key: 'refresh_token', value: response.refreshToken),
+      _dioClient.clearAuthCache(),
     ]);
   }
 }

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -85,8 +85,8 @@ class AuthRepositoryImpl implements AuthRepository {
     await Future.wait([
       _storage.write(key: 'access_token', value: response.accessToken),
       _storage.write(key: 'refresh_token', value: response.refreshToken),
-      _dioClient.clearAuthCache(),
     ]);
+    _dioClient.clearInMemoryCache();
   }
 }
 

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -81,11 +81,11 @@ class AuthRepositoryImpl implements AuthRepository {
     if (refreshToken == null) return;
     final response = await _dataSource.refresh(
       RefreshRequest(refreshToken: refreshToken),
+    );
     await Future.wait([
       _storage.write(key: 'access_token', value: response.accessToken),
       _storage.write(key: 'refresh_token', value: response.refreshToken),
     ]);
-    _dioClient.clearInMemoryCache();
     _dioClient.clearInMemoryCache();
   }
 }

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -81,11 +81,11 @@ class AuthRepositoryImpl implements AuthRepository {
     if (refreshToken == null) return;
     final response = await _dataSource.refresh(
       RefreshRequest(refreshToken: refreshToken),
-    );
     await Future.wait([
       _storage.write(key: 'access_token', value: response.accessToken),
       _storage.write(key: 'refresh_token', value: response.refreshToken),
     ]);
+    _dioClient.clearInMemoryCache();
     _dioClient.clearInMemoryCache();
   }
 }


### PR DESCRIPTION
## 💡 개요
JWT 리프레시 토큰 갱신 실패 버그를 수정합니다.
리프레시 토큰을 Authorization 헤더로 전달하던 것을 서버 스펙에 맞게 request body로 변경하고,
갱신 후 인터셉터의 stale 캐시를 무효화합니다.

## 🔗 관련 이슈
Closes #189

## 📃 작업내용
- `auth_interceptor.dart`: `_performRefresh()`에서 리프레시 토큰 전달 방식을 Authorization 헤더 → request body `{'refreshToken': ...}` 로 변경
- `auth_repository_impl.dart`: `refresh()` 성공 후 `clearAuthCache()` 호출하여 인터셉터의 stale `_cachedAccessToken` 무효화

## 🔍 테스트 방법
- 앱 재시작 후 액세스 토큰 만료 상태에서 자동으로 리프레시 토큰 갱신 확인
- 갱신 후 `me` API 호출 성공 확인

## 🖼️ 스크린샷
N/A

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

## ✅ 체크리스트
- [ ] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [ ] 불필요한 코드가 없는지 확인했습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 기존 기능이 정상적으로 작동하는지 확인했습니다.