### PR TITLE
🐛 iOS CD TestFlight 파이프라인 복구 (서명·api_key·MinimumOSVersion)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -5,21 +5,32 @@ default_platform(:ios)
 platform :ios do
   desc "Build the iOS app and upload it to TestFlight without submitting for review"
   lane :upload_testflight do
-    key_id = ENV["APP_STORE_CONNECT_KEY_ID"].to_s
-    issuer_id = ENV["APP_STORE_CONNECT_ISSUER_ID"].to_s
-    key_content = ENV["APP_STORE_CONNECT_API_KEY"].to_s
+    # 로컬에서 archive 단계만 검증할 때는 SKIP_TESTFLIGHT_UPLOAD=true 로 업로드를 건너뛴다.
+    # (App Store Connect API 키 없이도 빌드/서명 단계를 그대로 재현할 수 있다.)
+    skip_upload = ENV["SKIP_TESTFLIGHT_UPLOAD"] == "true"
 
-    UI.user_error!("APP_STORE_CONNECT_KEY_ID is empty") if key_id.strip.empty?
-    UI.user_error!("APP_STORE_CONNECT_ISSUER_ID is empty") if issuer_id.strip.empty?
-    UI.user_error!("APP_STORE_CONNECT_API_KEY is empty") if key_content.strip.empty?
+    api_key = nil
+    unless skip_upload
+      key_id = ENV["APP_STORE_CONNECT_KEY_ID"].to_s
+      issuer_id = ENV["APP_STORE_CONNECT_ISSUER_ID"].to_s
+      key_content = ENV["APP_STORE_CONNECT_API_KEY"].to_s
 
-    app_store_connect_api_key(
-      key_id: key_id,
-      issuer_id: issuer_id,
-      key_content: key_content,
-      is_key_content_base64: false,
-      in_house: false
-    )
+      UI.user_error!("APP_STORE_CONNECT_KEY_ID is empty") if key_id.strip.empty?
+      UI.user_error!("APP_STORE_CONNECT_ISSUER_ID is empty") if issuer_id.strip.empty?
+      UI.user_error!("APP_STORE_CONNECT_API_KEY is empty") if key_content.strip.empty?
+
+      # 반환된 Hash 를 upload_to_testflight 에 명시적으로 전달한다.
+      # APP_STORE_CONNECT_API_KEY 환경변수(원시 .p8 문자열)가 pilot 의 api_key 옵션과
+      # 이름이 겹쳐, 명시 전달하지 않으면 ENV 문자열이 api_key 로 들어가
+      # "'api_key' value must be a Hash! Found String instead." 로 실패한다.
+      api_key = app_store_connect_api_key(
+        key_id: key_id,
+        issuer_id: issuer_id,
+        key_content: key_content,
+        is_key_content_base64: false,
+        in_house: false
+      )
+    end
 
     build_number = ENV.fetch("IOS_BUILD_NUMBER")
     version_name = ENV.fetch("IOS_VERSION_NAME")
@@ -34,6 +45,20 @@ platform :ios do
         "--build-number=#{build_number}",
         "--dart-define=APP_ENV=production"
       ].join(" ")
+    )
+
+    # 수동 서명 설정을 Runner 타겟에만 적용한다.
+    # 과거엔 build_app의 xcargs로 PROVISIONING_PROFILE/CODE_SIGN_IDENTITY를 전역 주입했는데,
+    # 그러면 CocoaPods 라이브러리 타겟(nanopb, Firebase*, GoogleUtilities 등)에까지
+    # 프로비저닝 프로파일이 강제돼 "does not support provisioning profiles"로 archive가 실패한다.
+    update_code_signing_settings(
+      use_automatic_signing: false,
+      path: File.join(WORKSPACE, "ios", "Runner.xcodeproj"),
+      team_id: "UB2797YAAH",
+      code_sign_identity: "Apple Distribution",
+      profile_name: profile_uuid,
+      targets: ["Runner"],
+      build_configurations: ["Release"]
     )
 
     build_app(
@@ -51,11 +76,16 @@ platform :ios do
         provisioningProfiles: { "com.washer.v2" => profile_uuid }
       },
       output_directory: File.join(WORKSPACE, "build", "ios", "ipa"),
-      clean: true,
-      xcargs: "CODE_SIGN_STYLE=Manual PROVISIONING_PROFILE=#{profile_uuid} CODE_SIGN_IDENTITY='Apple Distribution' DEVELOPMENT_TEAM=UB2797YAAH"
+      clean: true
     )
 
+    if skip_upload
+      UI.success("SKIP_TESTFLIGHT_UPLOAD=true — archive 검증 완료, TestFlight 업로드는 건너뜀")
+      next
+    end
+
     upload_to_testflight(
+      api_key: api_key,
       skip_waiting_for_build_processing: true,
       distribute_external: false,
       notify_external_testers: false,
@@ -84,9 +114,11 @@ platform :android do
     aab_path = Dir.glob(File.join(aab_search_path, "*.aab")).max_by { |f| File.mtime(f) }
     UI.user_error!("AAB not found in #{aab_search_path}") if aab_path.nil?
 
+    # cd-android.yml에서 시크릿을 SUPPLY_JSON_KEY_DATA 환경변수로 주입한다.
+    # 과거엔 ENV["GOOGLE_PLAY_JSON_KEY"](미설정 → 빈 문자열)를 읽어 JSON 파싱이 깨졌다.
     upload_to_play_store(
       track: "internal",
-      json_key_data: ENV["GOOGLE_PLAY_JSON_KEY"],
+      json_key_data: ENV.fetch("SUPPLY_JSON_KEY_DATA"),
       aab: aab_path,
       skip_upload_apk: true,
       skip_upload_metadata: true,

--- a/ios/Flutter/AppFrameworkInfo.plist
+++ b/ios/Flutter/AppFrameworkInfo.plist
@@ -20,5 +20,7 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
+  <key>MinimumOSVersion</key>
+  <string>15.0</string>
 </dict>
 </plist>

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -39,5 +39,11 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+    target.build_configurations.each do |config|
+      # Pods 라이브러리 타겟은 서명이 필요 없다. 서명을 명시적으로 비활성화해
+      # archive 시 프로비저닝 프로파일이 강제되는 것을 방지한다.
+      config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
+      config.build_settings['CODE_SIGNING_REQUIRED'] = 'NO'
+    end
   end
 end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+1
+version: 1.0.1+1
 
 environment:
   sdk: ^3.9.2

--- a/scripts/test-ios-cd.sh
+++ b/scripts/test-ios-cd.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# 로컬에서 iOS CD 의 archive(서명) 단계를 TestFlight 업로드 없이 재현·검증한다.
+# main 에 push 하지 않고도 Fastfile/Podfile 서명 수정이 통과하는지 바로 확인할 수 있다.
+#
+# 사용법:
+#   scripts/test-ios-cd.sh <PROVISIONING_PROFILE_UUID>
+#   IOS_PROVISIONING_PROFILE_UUID=<uuid> scripts/test-ios-cd.sh
+#
+# 인자를 생략하면 설치된 프로비저닝 프로파일 목록(UUID)을 출력하고 종료한다.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# 프로비저닝 프로파일 경로: Xcode 16+ 신 경로 + 구 경로 모두 탐색
+PROFILE_DIRS=(
+  "$HOME/Library/Developer/Xcode/UserData/Provisioning Profiles"
+  "$HOME/Library/MobileDevice/Provisioning Profiles"
+)
+
+# 프로비저닝 프로파일 UUID 결정: 인자 > 환경변수
+PROFILE_UUID="${1:-${IOS_PROVISIONING_PROFILE_UUID:-}}"
+
+if [ -z "$PROFILE_UUID" ]; then
+  echo "❌ 프로비저닝 프로파일 UUID가 필요합니다."
+  echo ""
+  echo "사용법: scripts/test-ios-cd.sh <PROVISIONING_PROFILE_UUID>"
+  echo ""
+  echo "설치된 프로파일 (이름 → UUID):"
+  for dir in "${PROFILE_DIRS[@]}"; do
+    [ -d "$dir" ] || continue
+    for p in "$dir"/*.mobileprovision; do
+      [ -e "$p" ] || continue
+      name=$(security cms -D -i "$p" 2>/dev/null | plutil -extract Name raw - 2>/dev/null || echo "?")
+      uuid=$(security cms -D -i "$p" 2>/dev/null | plutil -extract UUID raw - 2>/dev/null || echo "?")
+      echo "  - $name → $uuid"
+    done
+  done
+  echo ""
+  echo "💡 app-store 업로드용은 보통 'Store Provisioning Profile: com.washer.v2' 입니다."
+  exit 1
+fi
+
+# update_code_signing_settings 가 Runner.xcodeproj/project.pbxproj 를 수정하므로,
+# 로컬 작업 트리를 더럽히지 않도록 테스트 종료 시 원본으로 복원한다.
+PBXPROJ="ios/Runner.xcodeproj/project.pbxproj"
+PBXPROJ_BACKUP="$(mktemp)"
+cp "$PBXPROJ" "$PBXPROJ_BACKUP"
+restore_pbxproj() {
+  cp "$PBXPROJ_BACKUP" "$PBXPROJ"
+  rm -f "$PBXPROJ_BACKUP"
+  echo "↩︎  project.pbxproj 원본 복원 완료"
+}
+trap restore_pbxproj EXIT
+
+# pubspec.yaml 에서 버전명 추출 (CI 의 Resolve iOS version metadata 단계와 동일 로직)
+VERSION_LINE="$(grep '^version:' pubspec.yaml | head -n 1 | awk '{print $2}')"
+VERSION_NAME="${VERSION_LINE%%+*}"
+
+export IOS_VERSION_NAME="$VERSION_NAME"
+export IOS_BUILD_NUMBER="${IOS_BUILD_NUMBER:-9999}"   # 로컬 테스트용 임시 빌드번호
+export IOS_PROVISIONING_PROFILE_UUID="$PROFILE_UUID"
+export SKIP_TESTFLIGHT_UPLOAD=true                    # 업로드 단계 건너뜀
+
+# 번들러(Gemfile.lock + 호환 Ruby)가 갖춰져 있으면 bundle exec, 아니면 글로벌 fastlane 사용
+if [ -f Gemfile.lock ] && bundle exec fastlane --version >/dev/null 2>&1; then
+  FASTLANE=(bundle exec fastlane)
+else
+  FASTLANE=(fastlane)
+fi
+
+echo "▶ 로컬 iOS CD 테스트"
+echo "  version       : $IOS_VERSION_NAME"
+echo "  build number  : $IOS_BUILD_NUMBER"
+echo "  profile uuid  : $IOS_PROVISIONING_PROFILE_UUID"
+echo "  upload        : SKIP"
+echo "  fastlane      : ${FASTLANE[*]}"
+echo ""
+
+"${FASTLANE[@]}" ios upload_testflight


### PR DESCRIPTION
## 개요
iOS CD(`cd-ios.yml` → fastlane `upload_testflight`)가 연속 실패하던 문제를 해결했습니다.
임시 테스트 브랜치(`test/ios-cd-signing-fix`)로 GitHub Actions에서 **빌드→서명→아카이브→TestFlight 업로드→내부 테스터 배포까지 전 구간 성공**을 확인했습니다.

## 고친 문제
| # | 증상 | 원인 | 해결 |
|---|---|---|---|
| 1 | `** ARCHIVE FAILED **` · `nanopb does not support provisioning profiles` | `build_app` 의 `xcargs` 로 `PROVISIONING_PROFILE`/`CODE_SIGN_IDENTITY` 를 **전역** 주입 → 모든 CocoaPods 라이브러리 타겟에 프로파일 강제 | `xcargs` 제거 후 `update_code_signing_settings` 로 **Runner 타겟만** 수동 서명. Podfile 에서 Pods 서명 비활성화 |
| 2 | `'api_key' value must be a Hash! Found String instead.` | `APP_STORE_CONNECT_API_KEY` 환경변수(원시 .p8 문자열)가 pilot 의 `api_key` 옵션명과 충돌 | `app_store_connect_api_key` 반환 Hash 를 `upload_to_testflight` 에 명시 전달 |
| 3 | altool `Invalid MinimumOSVersion` (빈 값) | `AppFrameworkInfo.plist` 에 `MinimumOSVersion` 키 누락 → `App.framework` Info.plist 빈 값 | `MinimumOSVersion 15.0` 추가 |
| 4 | `train '1.0.0' is closed` | 마케팅 버전 1.0.0 이 App Store Connect 에서 닫힘 | `pubspec` 버전 1.0.1 로 bump |

## 부가
- `SKIP_TESTFLIGHT_UPLOAD=true` 로 업로드 없이 archive 단계만 검증 가능
- `scripts/test-ios-cd.sh`: **main push 없이** 로컬에서 CD archive 단계를 재현하는 스크립트

🤖 Generated with [Claude Code](https://claude.com/claude-code)