### PR TITLE
✨ 태그 기반 App Store 자동 심사 제출 CD 추가

### DIFF
--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -1,0 +1,171 @@
+name: Release - iOS App Store
+
+# vX.Y.Z 형식의 버전 태그를 push 하면 그 버전으로 빌드해 App Store 심사에 자동 제출한다.
+# (예: git tag v1.0.2 && git push origin v1.0.2)
+# TestFlight 배포는 main 머지 시 cd-ios.yml 이 따로 담당한다.
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Build & Submit to App Store
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Set up Dart
+        uses: dart-lang/setup-dart@v1
+
+      - name: Install FVM
+        run: |
+          dart pub global activate fvm
+          echo "$HOME/.pub-cache/bin" >> "$GITHUB_PATH"
+
+      - name: Install Flutter via FVM
+        run: |
+          fvm install
+          fvm use --force
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Export CocoaPods bin to PATH
+        run: |
+          bundle binstubs cocoapods
+          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+
+      - name: Flutter pub get
+        run: fvm flutter pub get
+
+      - name: Flutter precache iOS artifacts
+        run: fvm flutter precache --ios
+
+      - name: Install CocoaPods dependencies
+        working-directory: ios
+        run: bundle exec pod install
+
+      - name: Restore production env
+        env:
+          ENV_PRODUCTION: ${{ secrets.ENV_PRODUCTION }}
+          ENV_DEVELOPMENT: ${{ secrets.ENV_DEVELOPMENT }}
+        run: |
+          if [ -z "$ENV_PRODUCTION" ] || [ -z "$ENV_DEVELOPMENT" ]; then
+            echo "::error::ENV_PRODUCTION or ENV_DEVELOPMENT secret is missing."
+            exit 1
+          fi
+          printf '%s' "$ENV_PRODUCTION" > .env.production
+          printf '%s' "$ENV_DEVELOPMENT" > .env.development
+
+      - name: Install Apple certificate and provisioning profile
+        env:
+          IOS_BUILD_CERTIFICATE_BASE64: ${{ secrets.IOS_BUILD_CERTIFICATE_BASE64 }}
+          IOS_P12_PASSWORD: ${{ secrets.IOS_P12_PASSWORD }}
+          IOS_BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.IOS_BUILD_PROVISION_PROFILE_BASE64 }}
+          IOS_KEYCHAIN_PASSWORD: ${{ secrets.IOS_KEYCHAIN_PASSWORD }}
+        run: |
+          if [ -z "$IOS_BUILD_CERTIFICATE_BASE64" ] || [ -z "$IOS_P12_PASSWORD" ] || \
+             [ -z "$IOS_BUILD_PROVISION_PROFILE_BASE64" ] || [ -z "$IOS_KEYCHAIN_PASSWORD" ]; then
+            echo "::error::iOS signing secrets are missing."
+            exit 1
+          fi
+
+          CERTIFICATE_PATH="$RUNNER_TEMP/build_certificate.p12"
+          PROFILE_PATH="$RUNNER_TEMP/build_pp.mobileprovision"
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+
+          printf '%s' "$IOS_BUILD_CERTIFICATE_BASE64" | base64 --decode > "$CERTIFICATE_PATH"
+          printf '%s' "$IOS_BUILD_PROVISION_PROFILE_BASE64" | base64 --decode > "$PROFILE_PATH"
+
+          security create-keychain -p "$IOS_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$IOS_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERTIFICATE_PATH" -P "$IOS_P12_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH" || {
+            echo "::error::Failed to import certificate into keychain."
+            exit 1
+          }
+          security list-keychain -d user -s "$KEYCHAIN_PATH" $(security list-keychain -d user | tr -d '"')
+          security set-key-partition-list -S apple-tool:,apple: -k "$IOS_KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          CERT_OUTPUT=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH")
+          echo "$CERT_OUTPUT"
+          if echo "$CERT_OUTPUT" | grep -qE "^\s+0 valid identities found"; then
+            echo "::error::No valid signing certificate found in keychain."
+            exit 1
+          fi
+
+          mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
+          cp "$PROFILE_PATH" "$HOME/Library/MobileDevice/Provisioning Profiles"
+
+          PROFILE_UUID=$(security cms -D -i "$PROFILE_PATH" | plutil -extract UUID raw -)
+          if [ -z "$PROFILE_UUID" ]; then
+            echo "::error::Failed to extract UUID from provisioning profile."
+            exit 1
+          fi
+          if [ ! -f "$HOME/Library/MobileDevice/Provisioning Profiles/build_pp.mobileprovision" ]; then
+            echo "::error::Provisioning profile not found in Provisioning Profiles directory."
+            exit 1
+          fi
+          echo "IOS_PROVISIONING_PROFILE_UUID=$PROFILE_UUID" >> "$GITHUB_ENV"
+
+      - name: Resolve iOS version from tag
+        run: |
+          TAG="${GITHUB_REF_NAME}"        # 예: v1.0.2
+          VERSION_NAME="${TAG#v}"         # 앞의 v 제거 → 1.0.2
+          if ! echo "$VERSION_NAME" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Tag '$TAG' is not a valid vX.Y.Z version tag."
+            exit 1
+          fi
+
+          echo "IOS_VERSION_NAME=$VERSION_NAME" >> "$GITHUB_ENV"
+          # 마케팅 버전은 태그에서, 빌드번호는 run number 로 (App Store 중복 방지)
+          echo "IOS_BUILD_NUMBER=${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
+
+      - name: Verify signing prerequisites
+        run: |
+          if [ -z "$IOS_PROVISIONING_PROFILE_UUID" ]; then
+            echo "::error::IOS_PROVISIONING_PROFILE_UUID is empty."
+            exit 1
+          fi
+          if [ -z "$IOS_VERSION_NAME" ]; then
+            echo "::error::IOS_VERSION_NAME is empty."
+            exit 1
+          fi
+          if [ -z "$IOS_BUILD_NUMBER" ]; then
+            echo "::error::IOS_BUILD_NUMBER is empty."
+            exit 1
+          fi
+          echo "Release version: $IOS_VERSION_NAME"
+          echo "Build number: $IOS_BUILD_NUMBER"
+          echo "Profile UUID: $IOS_PROVISIONING_PROFILE_UUID"
+
+      - name: Build & Submit to App Store
+        env:
+          APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_KEY }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+        run: bundle exec fastlane ios release_appstore
+
+      - name: Clean up keychain and provisioning profile
+        if: always()
+        run: |
+          security delete-keychain "$RUNNER_TEMP/app-signing.keychain-db" || true
+          rm -f "$RUNNER_TEMP/build_certificate.p12"
+          rm -f "$RUNNER_TEMP/build_pp.mobileprovision"
+          rm -f .env.production
+          rm -f .env.development

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -3,38 +3,94 @@ WORKSPACE = ENV.fetch("GITHUB_WORKSPACE", File.expand_path("..", __dir__))
 default_platform(:ios)
 
 platform :ios do
-  desc "Build the iOS app and upload it to TestFlight without submitting for review"
+  TEAM_ID = "UB2797YAAH"
+  BUNDLE_ID = "com.washer.v2"
+
+  desc "Build the iOS app and upload it to TestFlight without submitting for review (main 머지마다)"
   lane :upload_testflight do
     # 로컬에서 archive 단계만 검증할 때는 SKIP_TESTFLIGHT_UPLOAD=true 로 업로드를 건너뛴다.
     # (App Store Connect API 키 없이도 빌드/서명 단계를 그대로 재현할 수 있다.)
     skip_upload = ENV["SKIP_TESTFLIGHT_UPLOAD"] == "true"
+    api_key = skip_upload ? nil : load_asc_api_key
 
-    api_key = nil
-    unless skip_upload
-      key_id = ENV["APP_STORE_CONNECT_KEY_ID"].to_s
-      issuer_id = ENV["APP_STORE_CONNECT_ISSUER_ID"].to_s
-      key_content = ENV["APP_STORE_CONNECT_API_KEY"].to_s
+    build_signed_ipa(
+      version_name: ENV.fetch("IOS_VERSION_NAME"),
+      build_number: ENV.fetch("IOS_BUILD_NUMBER"),
+      profile_uuid: ENV.fetch("IOS_PROVISIONING_PROFILE_UUID")
+    )
 
-      UI.user_error!("APP_STORE_CONNECT_KEY_ID is empty") if key_id.strip.empty?
-      UI.user_error!("APP_STORE_CONNECT_ISSUER_ID is empty") if issuer_id.strip.empty?
-      UI.user_error!("APP_STORE_CONNECT_API_KEY is empty") if key_content.strip.empty?
-
-      # 반환된 Hash 를 upload_to_testflight 에 명시적으로 전달한다.
-      # APP_STORE_CONNECT_API_KEY 환경변수(원시 .p8 문자열)가 pilot 의 api_key 옵션과
-      # 이름이 겹쳐, 명시 전달하지 않으면 ENV 문자열이 api_key 로 들어가
-      # "'api_key' value must be a Hash! Found String instead." 로 실패한다.
-      api_key = app_store_connect_api_key(
-        key_id: key_id,
-        issuer_id: issuer_id,
-        key_content: key_content,
-        is_key_content_base64: false,
-        in_house: false
-      )
+    if skip_upload
+      UI.success("SKIP_TESTFLIGHT_UPLOAD=true — archive 검증 완료, TestFlight 업로드는 건너뜀")
+      next
     end
 
-    build_number = ENV.fetch("IOS_BUILD_NUMBER")
-    version_name = ENV.fetch("IOS_VERSION_NAME")
-    profile_uuid = ENV.fetch("IOS_PROVISIONING_PROFILE_UUID")
+    upload_to_testflight(
+      api_key: api_key,
+      skip_waiting_for_build_processing: true,
+      distribute_external: false,
+      notify_external_testers: false,
+      changelog: ENV["TESTFLIGHT_CHANGELOG"]
+    )
+  end
+
+  desc "Build the iOS app and submit it to App Store review (vX.Y.Z 태그 push 시)"
+  lane :release_appstore do
+    api_key = load_asc_api_key
+
+    build_signed_ipa(
+      version_name: ENV.fetch("IOS_VERSION_NAME"),
+      build_number: ENV.fetch("IOS_BUILD_NUMBER"),
+      profile_uuid: ENV.fetch("IOS_PROVISIONING_PROFILE_UUID")
+    )
+
+    # 바이너리를 App Store Connect 에 올리고 심사까지 자동 제출한다.
+    # - submit_for_review: 심사 제출까지 자동
+    # - automatic_release: false → 심사 승인 후 출시는 수동(안전). 승인 즉시 자동 출시하려면 true.
+    # - skip_metadata/skip_screenshots: 메타데이터·스크린샷은 fastlane 으로 관리하지 않음(이미 스토어에 존재).
+    #   ⚠️ 신규 버전의 "What's New(릴리스 노트)"는 App Store Connect 에서 채워야 심사 통과됨.
+    # - submission_information: IDFA 사용 여부 응답. 광고 SDK(IDFA) 사용 시 true 로 바꿔야 함.
+    upload_to_app_store(
+      api_key: api_key,
+      app_identifier: BUNDLE_ID,
+      submit_for_review: true,
+      automatic_release: false,
+      force: true,
+      run_precheck_before_submit: false,
+      skip_metadata: true,
+      skip_screenshots: true,
+      submission_information: {
+        add_id_info_uses_idfa: false
+      }
+    )
+  end
+
+  # App Store Connect API 키를 만들어 Hash 로 반환한다.
+  # APP_STORE_CONNECT_API_KEY 환경변수(원시 .p8 문자열)가 pilot/deliver 의 api_key 옵션과
+  # 이름이 겹쳐, 호출부에서 명시 전달하지 않으면 ENV 문자열이 api_key 로 들어가
+  # "'api_key' value must be a Hash! Found String instead." 로 실패한다.
+  private_lane :load_asc_api_key do
+    key_id = ENV["APP_STORE_CONNECT_KEY_ID"].to_s
+    issuer_id = ENV["APP_STORE_CONNECT_ISSUER_ID"].to_s
+    key_content = ENV["APP_STORE_CONNECT_API_KEY"].to_s
+
+    UI.user_error!("APP_STORE_CONNECT_KEY_ID is empty") if key_id.strip.empty?
+    UI.user_error!("APP_STORE_CONNECT_ISSUER_ID is empty") if issuer_id.strip.empty?
+    UI.user_error!("APP_STORE_CONNECT_API_KEY is empty") if key_content.strip.empty?
+
+    app_store_connect_api_key(
+      key_id: key_id,
+      issuer_id: issuer_id,
+      key_content: key_content,
+      is_key_content_base64: false,
+      in_house: false
+    )
+  end
+
+  # Flutter 빌드 + 수동 서명 아카이브로 app-store IPA 를 만든다. (TestFlight·App Store 공용)
+  private_lane :build_signed_ipa do |options|
+    version_name = options.fetch(:version_name)
+    build_number = options.fetch(:build_number)
+    profile_uuid = options.fetch(:profile_uuid)
 
     sh(
       [
@@ -54,7 +110,7 @@ platform :ios do
     update_code_signing_settings(
       use_automatic_signing: false,
       path: File.join(WORKSPACE, "ios", "Runner.xcodeproj"),
-      team_id: "UB2797YAAH",
+      team_id: TEAM_ID,
       code_sign_identity: "Apple Distribution",
       profile_name: profile_uuid,
       targets: ["Runner"],
@@ -67,29 +123,16 @@ platform :ios do
       configuration: "Release",
       export_options: {
         method: "app-store",
-        teamID: "UB2797YAAH",
+        teamID: TEAM_ID,
         signingStyle: "manual",
         signingCertificate: "Apple Distribution",
         stripSwiftSymbols: true,
         uploadBitcode: false,
         uploadSymbols: true,
-        provisioningProfiles: { "com.washer.v2" => profile_uuid }
+        provisioningProfiles: { BUNDLE_ID => profile_uuid }
       },
       output_directory: File.join(WORKSPACE, "build", "ios", "ipa"),
       clean: true
-    )
-
-    if skip_upload
-      UI.success("SKIP_TESTFLIGHT_UPLOAD=true — archive 검증 완료, TestFlight 업로드는 건너뜀")
-      next
-    end
-
-    upload_to_testflight(
-      api_key: api_key,
-      skip_waiting_for_build_processing: true,
-      distribute_external: false,
-      notify_external_testers: false,
-      changelog: ENV["TESTFLIGHT_CHANGELOG"]
     )
   end
 end


### PR DESCRIPTION
## 개요
이미 출시된 앱의 릴리스를 자동화하기 위해, **App Store 정식 심사 제출**을 CD에 추가했습니다.
TestFlight(QA)와 App Store(정식 릴리스)를 트리거로 분리합니다.

## 동작
| 트리거 | 워크플로우 | 동작 |
|---|---|---|
| `main` 머지 | `cd-ios.yml` (기존) | TestFlight 내부 배포, 빌드번호 자동 증가 |
| **`vX.Y.Z` 태그 push** | `release-ios.yml` (신규) | 태그 버전으로 빌드 → **App Store 심사 자동 제출** |

## 변경
- `release-ios.yml` 신규: 태그(`v[0-9]+.[0-9]+.[0-9]+`) 트리거. 버전=태그명, 빌드번호=run number.
- `Fastfile`: 빌드/서명 로직을 `build_signed_ipa` private_lane 으로 추출(TestFlight·App Store 공용), `load_asc_api_key` 추출, `release_appstore` 레인 추가(`upload_to_app_store`, `submit_for_review: true`, `automatic_release: false`).

## 검증
리팩터 후 TestFlight 경로가 정상인지 임시 테스트 브랜치로 실제 CI 실행 → `ARCHIVE SUCCEEDED` + `distributed build to Internal testers` 확인 완료.

## 릴리스 사용법
```bash
git tag v1.0.2 && git push origin v1.0.2
```

## ⚠️ 첫 실제 릴리스 시 확인
- **What's New(릴리스 노트)**: 신규 버전 심사 필수 → App Store Connect 에서 입력 (CD는 메타데이터 미관리)
- **IDFA**: 현재 `add_id_info_uses_idfa: false`. 광고 SDK로 IDFA 사용 시 `true`
- **출시**: 현재 승인 후 수동(`automatic_release: false`). 자동 출시 원하면 `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)