### PR TITLE
🐛 App Store 자동 제출 시 What's New 누락 수정 (태그 메시지 → 릴리스 노트)

### DIFF
--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # annotated 태그 메시지를 읽기 위해 전체 히스토리/태그 fetch
 
       - name: Set up Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -135,6 +137,26 @@ jobs:
           echo "IOS_VERSION_NAME=$VERSION_NAME" >> "$GITHUB_ENV"
           # 마케팅 버전은 태그에서, 빌드번호는 run number 로 (App Store 중복 방지)
           echo "IOS_BUILD_NUMBER=${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
+
+      - name: Prepare release notes from tag
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          # annotated 태그면 태그 메시지를, lightweight 태그면 빈 값을 사용
+          if [ "$(git cat-file -t "$TAG" 2>/dev/null)" = "tag" ]; then
+            NOTES="$(git tag -l --format='%(contents)' "$TAG")"
+          else
+            NOTES=""
+          fi
+          # 비어 있으면(= lightweight 태그 또는 메시지 없음) 기본 문구로 대체
+          if [ -z "$(printf '%s' "$NOTES" | tr -d '[:space:]')" ]; then
+            echo "::warning::태그에 메시지가 없습니다. 기본 릴리스 노트를 사용합니다. (다음부터 git tag -a vX.Y.Z -m \"내용\" 권장)"
+            NOTES="버그 수정 및 안정성 개선"
+          fi
+          # App Store 등록 언어(ko)에 What's New 작성. (등록 언어 추가 시 디렉터리 추가 필요)
+          mkdir -p fastlane/metadata/ko
+          printf '%s\n' "$NOTES" > fastlane/metadata/ko/release_notes.txt
+          echo "----- release_notes (ko) -----"
+          cat fastlane/metadata/ko/release_notes.txt
 
       - name: Verify signing prerequisites
         run: |

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -46,8 +46,10 @@ platform :ios do
     # 바이너리를 App Store Connect 에 올리고 심사까지 자동 제출한다.
     # - submit_for_review: 심사 제출까지 자동
     # - automatic_release: false → 심사 승인 후 출시는 수동(안전). 승인 즉시 자동 출시하려면 true.
-    # - skip_metadata/skip_screenshots: 메타데이터·스크린샷은 fastlane 으로 관리하지 않음(이미 스토어에 존재).
-    #   ⚠️ 신규 버전의 "What's New(릴리스 노트)"는 App Store Connect 에서 채워야 심사 통과됨.
+    # - skip_metadata: false → fastlane/metadata/<locale>/release_notes.txt 의 "What's New" 만 업로드.
+    #   (다른 메타데이터 파일이 없으면 deliver 가 해당 필드를 건드리지 않음 = 기존 값 유지)
+    #   release_notes.txt 는 release-ios.yml 이 태그 메시지로부터 빌드 직전에 생성한다.
+    # - skip_screenshots: 스크린샷은 관리하지 않음(이미 스토어에 존재).
     # - submission_information: IDFA 사용 여부 응답. 광고 SDK(IDFA) 사용 시 true 로 바꿔야 함.
     upload_to_app_store(
       api_key: api_key,
@@ -56,7 +58,7 @@ platform :ios do
       automatic_release: false,
       force: true,
       run_precheck_before_submit: false,
-      skip_metadata: true,
+      skip_metadata: false,
       skip_screenshots: true,
       submission_information: {
         add_id_info_uses_idfa: false


### PR DESCRIPTION
## 문제
v1.0.2 태그로 `release-ios.yml` 이 돌았으나 마지막 심사 제출에서 실패:
```
You must provide a value for the attribute 'whatsNew'
```
빌드·서명·바이너리 업로드·버전(1.0.2) 생성까지는 성공했고, **"What's New(릴리스 노트)"가 비어** 심사 제출만 거부됨.

## 해결
- `release-ios.yml`: annotated 태그 메시지를 `fastlane/metadata/ko/release_notes.txt` 로 생성 (메시지 없으면 기본 문구). `fetch-depth: 0` 로 태그 메시지 접근.
- `Fastfile`: `upload_to_app_store` 의 `skip_metadata: false` 로 릴리스 노트만 업로드 (다른 메타데이터 파일은 없으므로 기존 값 유지).

## 사용법
```bash
git tag -a v1.0.3 -m "버그 수정 및 개선"
git push origin v1.0.3
```
→ 태그 메시지가 그대로 App Store "이번 버전의 새로운 기능"에 들어가고 심사 자동 제출.

## 참고
앱 App Store 등록 언어 = 한국어(ko) 단일 기준. 등록 언어 추가 시 워크플로우에 로케일 디렉터리 추가 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)