### PR TITLE
✨ App Store 자동 제출을 main 머지 트리거로 전환 (+ 버전 자동 증가 / 심사중 스킵 가드)

### DIFF
--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -1,12 +1,14 @@
 name: Release - iOS App Store
 
-# vX.Y.Z 형식의 버전 태그를 push 하면 그 버전으로 빌드해 App Store 심사에 자동 제출한다.
-# (예: git tag v1.0.2 && git push origin v1.0.2)
-# TestFlight 배포는 main 머지 시 cd-ios.yml 이 따로 담당한다.
+# main 에 push(머지)되면 App Store 심사에 자동 제출한다.
+# - 마케팅 버전은 App Store Connect 최신 버전 +패치로 자동 증가 (Fastfile resolve_next_appstore_version)
+# - 릴리스 노트는 머지 커밋 메시지(PR 제목)에서 가져옴, 없으면 기본 문구
+# TestFlight 배포는 cd-ios.yml 이 따로 담당(같은 main push 로 동시 동작).
+# ⚠️ Apple 은 한 번에 버전 1개만 심사 → main 은 릴리스용으로 사용 권장.
 on:
   push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -125,31 +127,17 @@ jobs:
           fi
           echo "IOS_PROVISIONING_PROFILE_UUID=$PROFILE_UUID" >> "$GITHUB_ENV"
 
-      - name: Resolve iOS version from tag
+      - name: Resolve build number
         run: |
-          TAG="${GITHUB_REF_NAME}"        # 예: v1.0.2
-          VERSION_NAME="${TAG#v}"         # 앞의 v 제거 → 1.0.2
-          if ! echo "$VERSION_NAME" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "::error::Tag '$TAG' is not a valid vX.Y.Z version tag."
-            exit 1
-          fi
-
-          echo "IOS_VERSION_NAME=$VERSION_NAME" >> "$GITHUB_ENV"
-          # 마케팅 버전은 태그에서, 빌드번호는 run number 로 (App Store 중복 방지)
+          # 마케팅 버전은 Fastfile 이 App Store Connect 조회로 자동 결정한다.
+          # 여기선 빌드번호만 run number 로 고정(App Store 빌드 중복 방지).
           echo "IOS_BUILD_NUMBER=${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
 
-      - name: Prepare release notes from tag
+      - name: Prepare release notes
         run: |
-          TAG="${GITHUB_REF_NAME}"
-          # annotated 태그면 태그 메시지를, lightweight 태그면 빈 값을 사용
-          if [ "$(git cat-file -t "$TAG" 2>/dev/null)" = "tag" ]; then
-            NOTES="$(git tag -l --format='%(contents)' "$TAG")"
-          else
-            NOTES=""
-          fi
-          # 비어 있으면(= lightweight 태그 또는 메시지 없음) 기본 문구로 대체
+          # 머지 커밋 메시지 본문(보통 PR 제목)을 릴리스 노트로 사용, 비면 기본 문구.
+          NOTES="$(git log -1 --format=%b HEAD | sed '/^[[:space:]]*$/d' | head -n 10)"
           if [ -z "$(printf '%s' "$NOTES" | tr -d '[:space:]')" ]; then
-            echo "::warning::태그에 메시지가 없습니다. 기본 릴리스 노트를 사용합니다. (다음부터 git tag -a vX.Y.Z -m \"내용\" 권장)"
             NOTES="버그 수정 및 안정성 개선"
           fi
           # App Store 등록 언어(ko)에 What's New 작성. (등록 언어 추가 시 디렉터리 추가 필요)
@@ -164,15 +152,10 @@ jobs:
             echo "::error::IOS_PROVISIONING_PROFILE_UUID is empty."
             exit 1
           fi
-          if [ -z "$IOS_VERSION_NAME" ]; then
-            echo "::error::IOS_VERSION_NAME is empty."
-            exit 1
-          fi
           if [ -z "$IOS_BUILD_NUMBER" ]; then
             echo "::error::IOS_BUILD_NUMBER is empty."
             exit 1
           fi
-          echo "Release version: $IOS_VERSION_NAME"
           echo "Build number: $IOS_BUILD_NUMBER"
           echo "Profile UUID: $IOS_PROVISIONING_PROFILE_UUID"
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,12 +33,24 @@ platform :ios do
     )
   end
 
-  desc "Build the iOS app and submit it to App Store review (vX.Y.Z 태그 push 시)"
+  desc "Build the iOS app and submit it to App Store review (main 머지마다)"
   lane :release_appstore do
     api_key = load_asc_api_key
+    setup_connect_api(api_key: api_key)
+
+    # 이미 심사 대기/진행 중인 버전이 있으면 새 제출을 건너뛴다.
+    # (Apple 은 한 번에 한 버전만 심사 → main 에 자주 머지돼도 실패하지 않고 스킵)
+    if appstore_review_in_progress
+      UI.important("이미 심사 대기/진행 중인 버전이 있어 이번 App Store 제출은 건너뜁니다. (TestFlight 는 cd-ios.yml 이 처리)")
+      next
+    end
+
+    # 마케팅 버전은 App Store Connect 의 현재 최고 버전 +패치로 자동 증가시킨다.
+    # (main 머지마다 새 버전을 올려야 train 닫힘으로 실패하지 않음)
+    version_name = resolve_next_appstore_version
 
     build_signed_ipa(
-      version_name: ENV.fetch("IOS_VERSION_NAME"),
+      version_name: version_name,
       build_number: ENV.fetch("IOS_BUILD_NUMBER"),
       profile_uuid: ENV.fetch("IOS_PROVISIONING_PROFILE_UUID")
     )
@@ -48,7 +60,7 @@ platform :ios do
     # - automatic_release: false → 심사 승인 후 출시는 수동(안전). 승인 즉시 자동 출시하려면 true.
     # - skip_metadata: false → fastlane/metadata/<locale>/release_notes.txt 의 "What's New" 만 업로드.
     #   (다른 메타데이터 파일이 없으면 deliver 가 해당 필드를 건드리지 않음 = 기존 값 유지)
-    #   release_notes.txt 는 release-ios.yml 이 태그 메시지로부터 빌드 직전에 생성한다.
+    #   release_notes.txt 는 release-ios.yml 이 머지 커밋 메시지로부터 빌드 직전에 생성한다.
     # - skip_screenshots: 스크린샷은 관리하지 않음(이미 스토어에 존재).
     # - submission_information: IDFA 사용 여부 응답. 광고 SDK(IDFA) 사용 시 true 로 바꿔야 함.
     upload_to_app_store(
@@ -86,6 +98,52 @@ platform :ios do
       is_key_content_base64: false,
       in_house: false
     )
+  end
+
+  # App Store Connect API 토큰을 Spaceship 에 설정한다. (직접 Spaceship 조회 전에 1회 호출)
+  private_lane :setup_connect_api do |options|
+    api_key = options.fetch(:api_key)
+    require "spaceship"
+    Spaceship::ConnectAPI.token = Spaceship::ConnectAPI::Token.create(
+      key_id: api_key[:key_id],
+      issuer_id: api_key[:issuer_id],
+      key: api_key[:key]
+    )
+  end
+
+  # 심사 대기/진행 중이라 새 제출이 막히는 버전이 있는지 확인한다. (setup_connect_api 선행 필요)
+  private_lane :appstore_review_in_progress do
+    app = Spaceship::ConnectAPI::App.find(BUNDLE_ID)
+    if app.nil?
+      false
+    else
+      blocking = %w[
+        WAITING_FOR_REVIEW
+        IN_REVIEW
+        PENDING_APPLE_RELEASE
+        PROCESSING_FOR_APP_STORE
+      ]
+      app.get_app_store_versions.any? { |v| blocking.include?(v.app_store_state) }
+    end
+  end
+
+  # App Store Connect 의 현재 최고 마케팅 버전을 조회해 patch +1 한 버전 문자열을 반환한다.
+  # (라이브/심사중/편집중 버전을 모두 포함한 최댓값 기준 → 진행 중 버전과 충돌 방지)
+  # setup_connect_api 선행 필요.
+  private_lane :resolve_next_appstore_version do
+    app = Spaceship::ConnectAPI::App.find(BUNDLE_ID)
+    UI.user_error!("App #{BUNDLE_ID} 를 App Store Connect 에서 찾지 못했습니다") if app.nil?
+
+    versions = app.get_app_store_versions
+    current = versions.map { |v| Gem::Version.new(v.version_string) }.max || Gem::Version.new("1.0.0")
+
+    seg = current.segments.dup
+    seg << 0 while seg.size < 3
+    seg[2] += 1
+    next_version = seg[0, 3].join(".")
+
+    UI.message("App Store 다음 버전 자동 결정: #{next_version} (현재 최고 #{current})")
+    next_version
   end
 
   # Flutter 빌드 + 수동 서명 아카이브로 app-store IPA 를 만든다. (TestFlight·App Store 공용)


### PR DESCRIPTION
## 개요
App Store 심사 제출 트리거를 **태그 → main push(머지)** 로 변경. TestFlight(`cd-ios.yml`)는 그대로 main 머지마다 동작.

## 변경
- `release-ios.yml`: `on.push.branches: [main]`. 빌드번호=run number, 릴리스 노트=머지 커밋 메시지(없으면 기본).
- `Fastfile`:
  - `resolve_next_appstore_version`: App Store Connect 최고 버전 +patch 자동 증가 (Spaceship).
  - `appstore_review_in_progress` 가드: 심사 대기/진행 중 버전 있으면 제출 **스킵**(빌드 전). Apple 은 한 번에 한 버전만 심사하므로, 잦은 머지에도 실패하지 않음.
  - `setup_connect_api`: Spaceship 토큰 설정.

## 동작 요약
| 상황 | 결과 |
|---|---|
| 심사 중 버전 없음 | 다음 버전 자동 생성 → 빌드 → App Store 심사 제출 |
| 심사 중 버전 있음(예: 현재 1.0.2) | App Store 제출 **스킵**(로그), TestFlight 만 진행 |

## ⚠️ 운영 메모
- Apple 한 번에 한 버전 심사 제약 때문에, 심사 중이면 자동 스킵됨(의도된 동작).
- 릴리스 노트는 머지 커밋(PR 제목) 기반. 더 다듬으려면 ASC 에서 승인 전 수정 가능.
- 승인 후 출시는 수동(`automatic_release: false`).
- 이 경로(자동증가/제출)는 실 제출이라야 검증되며, 첫 실제 동작은 1.0.2 심사 종료 후 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)