### PR TITLE
🔧 Android 패키지명(com.washer.v2) 정렬 + Play 키 없을 때 CD skip

### DIFF
--- a/.github/workflows/cd-android.yml
+++ b/.github/workflows/cd-android.yml
@@ -10,8 +10,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # GOOGLE_PLAY_JSON_KEY(서비스 계정) 미설정이면 배포를 건너뛴다.
+  # (Android Play Store 설정 전까지 워크플로우가 빨갛게 실패하지 않도록 — 키 등록 시 자동 활성화)
+  guard:
+    name: Check Play Store credentials
+    runs-on: ubuntu-latest
+    outputs:
+      configured: ${{ steps.check.outputs.configured }}
+    steps:
+      - name: Check GOOGLE_PLAY_JSON_KEY
+        id: check
+        env:
+          GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
+        run: |
+          if [ -n "$GOOGLE_PLAY_JSON_KEY" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::GOOGLE_PLAY_JSON_KEY 미설정 — Android internal 배포를 건너뜁니다. (시크릿 등록 시 자동 활성화)"
+          fi
+
   deploy:
     name: Build & Upload to Play Store
+    needs: guard
+    if: needs.guard.outputs.configured == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -14,8 +14,30 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # GOOGLE_PLAY_JSON_KEY(서비스 계정) 미설정이면 배포를 건너뛴다.
+  # (Android Play Store 설정 전까지 워크플로우가 빨갛게 실패하지 않도록 — 키 등록 시 자동 활성화)
+  guard:
+    name: Check Play Store credentials
+    runs-on: ubuntu-latest
+    outputs:
+      configured: ${{ steps.check.outputs.configured }}
+    steps:
+      - name: Check GOOGLE_PLAY_JSON_KEY
+        id: check
+        env:
+          GOOGLE_PLAY_JSON_KEY: ${{ secrets.GOOGLE_PLAY_JSON_KEY }}
+        run: |
+          if [ -n "$GOOGLE_PLAY_JSON_KEY" ]; then
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::GOOGLE_PLAY_JSON_KEY 미설정 — Android production 배포를 건너뜁니다. (시크릿 등록 시 자동 활성화)"
+          fi
+
   release:
     name: Build & Release to Play Store (production)
+    needs: guard
+    if: needs.guard.outputs.configured == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -36,7 +36,9 @@ android {
     }
 
     defaultConfig {
-        applicationId = "com.washer"
+        // 배포 ID 는 Play Console 등록 패키지(com.washer.v2)에 맞춘다.
+        // namespace(코드용 R/BuildConfig)는 com.washer 유지 — MainActivity 패키지/매니페스트와 정합.
+        applicationId = "com.washer.v2"
         minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode


### PR DESCRIPTION
## Describe
#196 후속 수정.

1. **applicationId → `com.washer.v2`** : Play Console 등록 패키지에 맞춤
   - `namespace` 는 `com.washer` 유지 (매니페스트 `.MainActivity` + `MainActivity.kt(package com.washer)` 정합. namespace≠applicationId 는 표준 구성)
2. **Android CD skip 가드** : `GOOGLE_PLAY_JSON_KEY` 시크릿이 없으면 `guard` 잡이 배포 잡을 건너뛰어 워크플로우가 실패(빨강)하지 않게 함. 키 등록 시 자동 활성화. (cd-android, release-android 둘 다)

## ⚠️ Android 정식 활성화 시 남은 작업 (추후)
- `GOOGLE_PLAY_JSON_KEY` 시크릿 등록 (Play 서비스 계정 JSON, raw)
- **Firebase 에 `com.washer.v2` Android 앱 추가** 후 `google-services.json` / `ANDROID_GOOGLE_SERVICES_JSON` 시크릿 교체 (현재 `com.washer` 등록 → applicationId 와 불일치 시 release 빌드의 google-services 단계 실패)
- production 트랙 최초 1회 콘솔 수동 출시

🤖 Generated with [Claude Code](https://claude.com/claude-code)