### PR TITLE
🐛 Android 핫픽스: MainActivity ClassNotFoundException 해소 (+ versionCode 충돌)

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -119,8 +119,10 @@ jobs:
           fi
 
           echo "ANDROID_VERSION_NAME=$VERSION_NAME" >> "$GITHUB_ENV"
-          # pubspec의 build number 대신 run number를 사용해 Play Store 중복을 방지
-          echo "ANDROID_BUILD_NUMBER=${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
+          # versionCode 는 업로드마다 단조 증가해야 하며 Play 의 기존 최고값보다 커야 한다.
+          # run number 만 쓰면 과거(내부 트랙/수동) 업로드가 쓴 낮은 코드와 충돌하므로
+          # 1000 오프셋을 더해 기존 코드 위로 띄운다. (run number 가 계속 증가하므로 단조성 유지)
+          echo "ANDROID_BUILD_NUMBER=$((1000 + GITHUB_RUN_NUMBER))" >> "$GITHUB_ENV"
 
       - name: Release to Play Store (production)
         env:

--- a/android/app/src/main/kotlin/com/washer/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/washer/MainActivity.kt
@@ -1,4 +1,4 @@
-﻿package com.washer.v2
+package com.washer
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.8+1
+version: 1.0.9+1
 
 environment:
   sdk: ^3.9.2


### PR DESCRIPTION
## 개요
Android release 빌드/실행 시 발생하던 문제를 해소합니다.

## 변경 사항
### 1. MainActivity ClassNotFoundException 해소 (이번 PR 핵심)
- **증상:** `java.lang.ClassNotFoundException: Didn't find class "com.washer.MainActivity"`
- **원인:** 매니페스트의 `android:name=".MainActivity"`는 `namespace`(`com.washer`) 기준으로 해석되어 `com.washer.MainActivity`를 찾는데, 실제 클래스는 `com.washer.v2` 패키지에 있어 불일치 발생.
- **수정:** `MainActivity.kt`를 `com.washer.v2` → `com.washer` 패키지로 이동. `applicationId`(`com.washer.v2`, Play Console 등록 패키지)는 그대로 유지.

### 2. versionCode 충돌 해소 (기존 커밋)
- Android 1.0.9 + run number에 1000 오프셋 적용.

## 테스트
- `flutter run --debug` / `--profile`로 앱 정상 실행 확인 필요 (로컬 release는 키스토어 별도 필요).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
