### PR TITLE
🔀 :: (#207) - 앱 버전 불일치시 팝업 생성 로직 작성

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -57,5 +57,9 @@
             <action android:name="android.intent.action.PROCESS_TEXT" />
             <data android:mimeType="text/plain" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" />
+        </intent>
     </queries>
 </manifest>

--- a/lib/core/services/version_check_service.dart
+++ b/lib/core/services/version_check_service.dart
@@ -13,11 +13,14 @@ class VersionCheckService {
   ///
   /// 최신 버전이거나, 네트워크 오류·스토어 미게시·버전 파싱 실패 등으로
   /// 판단할 수 없는 경우에는 사용자의 앱 진입을 막지 않도록 `null`을 반환한다.
+  ///
+  /// 스토어 링크가 비어 있으면 업데이트 버튼을 눌러도 아무 동작을 할 수 없어
+  /// 사용자가 앱에 갇히므로, 이 경우에도 진입을 막지 않도록 `null`을 반환한다.
   Future<VersionStatus?> fetchUpdatableStatus() async {
     try {
       final newVersion = NewVersionPlus();
       final status = await newVersion.getVersionStatus();
-      if (status == null || !status.canUpdate) {
+      if (status == null || !status.canUpdate || status.appStoreLink.isEmpty) {
         return null;
       }
       return status;
@@ -44,7 +47,16 @@ class VersionCheckService {
     }
 
     try {
-      await launchUrl(uri, mode: LaunchMode.externalApplication);
+      final launched = await launchUrl(
+        uri,
+        mode: LaunchMode.externalApplication,
+      );
+      if (!launched) {
+        AppLogger.error(
+          '스토어 페이지를 여는 데 실패했습니다. (launchUrl returned false)',
+          name: 'VersionCheckService',
+        );
+      }
     } catch (error, stackTrace) {
       AppLogger.error(
         '스토어 페이지를 여는 중 오류가 발생했습니다.',

--- a/lib/core/services/version_check_service.dart
+++ b/lib/core/services/version_check_service.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:new_version_plus/new_version_plus.dart';
+import 'package:new_version_plus/model/version_status.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:washer/core/utils/app_logger.dart';
+
+/// 스토어(App Store / Play Store)에 게시된 최신 버전과
+/// 현재 설치된 앱 버전(pubspec.yaml 기준)을 비교한다.
+class VersionCheckService {
+  const VersionCheckService();
+
+  /// 업데이트가 필요한 경우(스토어 버전 > 현재 버전)에만 스토어 정보를 반환한다.
+  ///
+  /// 최신 버전이거나, 네트워크 오류·스토어 미게시·버전 파싱 실패 등으로
+  /// 판단할 수 없는 경우에는 사용자의 앱 진입을 막지 않도록 `null`을 반환한다.
+  Future<VersionStatus?> fetchUpdatableStatus() async {
+    try {
+      final newVersion = NewVersionPlus();
+      final status = await newVersion.getVersionStatus();
+      if (status == null || !status.canUpdate) {
+        return null;
+      }
+      return status;
+    } catch (error, stackTrace) {
+      AppLogger.error(
+        '앱 버전 확인 중 오류가 발생했습니다.',
+        name: 'VersionCheckService',
+        error: error,
+        stackTrace: stackTrace,
+      );
+      return null;
+    }
+  }
+
+  /// 전달받은 스토어 링크를 외부 앱(스토어)에서 연다.
+  Future<void> openStore(String storeLink) async {
+    if (storeLink.isEmpty) {
+      return;
+    }
+
+    final uri = Uri.tryParse(storeLink);
+    if (uri == null) {
+      return;
+    }
+
+    try {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } catch (error, stackTrace) {
+      AppLogger.error(
+        '스토어 페이지를 여는 중 오류가 발생했습니다.',
+        name: 'VersionCheckService',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+}
+
+final versionCheckServiceProvider = Provider<VersionCheckService>(
+  (_) => const VersionCheckService(),
+);

--- a/lib/core/ui/dialog/force_update_dialog.dart
+++ b/lib/core/ui/dialog/force_update_dialog.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:washer/core/theme/color.dart';
+import 'package:washer/core/theme/spacing.dart';
+import 'package:washer/core/ui/dialog/washer_dialog.dart';
+
+/// 앱이 최신 버전이 아닐 때 초기 진입에서 강제로 노출되는 업데이트 팝업.
+///
+/// 선택지는 "업데이트 하기" 단 하나이며, 바깥 영역 탭이나
+/// 뒤로가기로 닫을 수 없다.
+class ForceUpdateDialog extends StatelessWidget {
+  const ForceUpdateDialog({super.key, required this.onUpdatePressed});
+
+  final VoidCallback onUpdatePressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: false,
+      child: Dialog(
+        backgroundColor: Colors.transparent,
+        insetPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+        child: WasherDialog(
+          title: '현재 앱은 최신 버전이 아닙니다!',
+          backText: '업데이트 하기',
+          backColor: WasherColor.mainColor400,
+          confirmText: '',
+          onBackPressed: onUpdatePressed,
+          content: Padding(
+            padding: EdgeInsets.symmetric(vertical: AppSpacing.v16),
+            child: const SizedBox.shrink(),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/splash_screen.dart
+++ b/lib/splash_screen.dart
@@ -6,8 +6,10 @@ import 'package:go_router/go_router.dart';
 import 'package:washer/core/network/dio_client.dart';
 import 'package:washer/core/network/token_utils.dart';
 import 'package:washer/core/router/route_paths.dart';
+import 'package:washer/core/services/version_check_service.dart';
 import 'package:washer/core/theme/icon.dart';
 import 'package:washer/core/ui/base_scaffold.dart';
+import 'package:washer/core/ui/dialog/force_update_dialog.dart';
 import 'package:washer/core/utils/app_logger.dart';
 import 'package:washer/features/user/data/data_sources/remote/user_remote_data_source.dart';
 import 'package:washer/features/user/presentation/providers/my_user_provider.dart';
@@ -29,6 +31,10 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
   }
 
   Future<void> _bootstrap() async {
+    if (await _handleForceUpdate()) {
+      return;
+    }
+
     final storage = ref.read(secureStorageProvider);
     final accessToken = await storage.read(key: 'access_token');
     final refreshToken = await storage.read(key: 'refresh_token');
@@ -96,6 +102,32 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
     ref.read(myUserProvider.notifier).clear();
     if (!mounted) return;
     context.go(RoutePaths.login);
+  }
+
+  /// 앱이 최신 버전이 아니면 강제 업데이트 팝업을 띄운다.
+  ///
+  /// 업데이트가 필요해 팝업을 노출한 경우 `true`를 반환하여
+  /// 이후 초기화(인증/홈 진입)를 중단시킨다.
+  Future<bool> _handleForceUpdate() async {
+    final versionCheckService = ref.read(versionCheckServiceProvider);
+    final status = await versionCheckService.fetchUpdatableStatus();
+
+    if (status == null) {
+      return false;
+    }
+
+    if (!mounted) return true;
+
+    final storeLink = status.appStoreLink;
+    await showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => ForceUpdateDialog(
+        onUpdatePressed: () => versionCheckService.openStore(storeLink),
+      ),
+    );
+
+    return true;
   }
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -209,6 +209,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
+  device_info_plus:
+    dependency: transitive
+    description:
+      name: device_info_plus
+      sha256: a7fd703482b391a87d60b6061d04dfdeab07826b96f9abd8f5ed98068acc0074
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.2"
+  device_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: device_info_plus_platform_interface
+      sha256: e1ea89119e34903dca74b883d0dd78eb762814f97fb6c76f35e9ff74d261a18f
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.3"
   dio:
     dependency: "direct main"
     description:
@@ -540,10 +556,10 @@ packages:
     dependency: transitive
     description:
       name: http
-      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -696,6 +712,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  new_version_plus:
+    dependency: "direct main"
+    description:
+      name: new_version_plus
+      sha256: "5a8ff14d7b93c60e7a42e1dd3e9fc3290fd76864faa180cd649615769d19b4e9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   node_preamble:
     dependency: transitive
     description:
@@ -712,6 +736,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  package_info_plus:
+    dependency: transitive
+    description:
+      name: package_info_plus
+      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: transitive
     description:
@@ -1029,6 +1069,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "17bc677f0b301615530dd1d67e0a9828cafa2d0b6b6eae4cd3679b7eac4a273c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.30"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   vector_graphics:
     dependency: transitive
     description:
@@ -1149,6 +1253,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.15.0"
+  win32_registry:
+    dependency: transitive
+    description:
+      name: win32_registry
+      sha256: "21ec76dfc731550fd3e2ce7a33a9ea90b828fdf19a5c3bcf556fa992cfa99852"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.5"
   xdg_directories:
     dependency: transitive
     description:
@@ -1182,5 +1294,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.35.0"
+  dart: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,8 @@ dependencies:
   flutter_screenutil: 5.9.3
   firebase_crashlytics: ^5.0.3
   firebase_analytics: ^12.0.3
+  new_version_plus: 1.0.1
+  url_launcher: 6.3.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 개요
앱 초기 진입(스플래시) 시 현재 앱 버전이 스토어 최신 버전보다 낮으면, 닫을 수 없는 강제 업데이트 팝업을 노출합니다.

Closes #207

## 변경 사항
- **`pubspec.yaml`**: `new_version_plus`(스토어 버전 조회), `url_launcher`(스토어 열기) 추가
- **`VersionCheckService`** (신규): 스토어 버전 > 현재 버전일 때만 업데이트 정보 반환. 네트워크 오류·미게시·파싱 실패 시 `null`을 반환해 사용자 진입을 막지 않음
- **`ForceUpdateDialog`** (신규): 기존 `WasherDialog` 재사용, 단일 "업데이트 하기" 버튼. `PopScope(canPop: false)` + `barrierDismissible: false`로 뒤로가기·바깥 탭 차단
- **`splash_screen.dart`**: 부트스트랩 최상단에서 버전 확인 → 업데이트 필요 시 팝업 노출 후 인증/홈 진입 중단
- **`AndroidManifest.xml`**: `<queries>`에 https `VIEW` intent 추가 (Android 11+에서 스토어 링크 오픈)

## 동작
- 메시지: **"현재 앱은 최신 버전이 아닙니다!"**
- 선택지: **"업데이트 하기"** 단 하나 → 탭 시 스토어 페이지로 이동
- 현재 버전: 빌드 버전(pubspec.yaml 기준) / 최신 버전: App Store · Play Store 조회

## 검증
- `flutter analyze` 전체 통과 (No issues found)
- Android 에뮬레이터에서 팝업 노출 및 "업데이트 하기" → Play Store 이동, 뒤로가기 시 팝업 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
