### PR TITLE
🔀 :: (#210) -  예약 중복 방지 및 로딩 인디케이터 개선 

### DIFF
--- a/lib/core/ui/dialog/laundry_status_dialog.dart
+++ b/lib/core/ui/dialog/laundry_status_dialog.dart
@@ -8,6 +8,7 @@ import 'package:washer/core/enums/machine_state.dart';
 import 'package:washer/core/theme/spacing.dart';
 import 'package:washer/core/theme/typography.dart';
 import 'package:washer/core/ui/dialog/washer_dialog.dart';
+import 'package:washer/core/ui/loading_overlay.dart';
 import 'package:washer/core/utils/app_logger.dart';
 import 'package:washer/core/utils/date_time_formatter.dart';
 import 'package:washer/core/utils/room_formatter.dart';
@@ -84,6 +85,7 @@ class LaundryStatusDialog extends ConsumerWidget {
                 final messenger = ScaffoldMessenger.of(context);
                 final navigator = Navigator.of(context);
                 final container = ProviderScope.containerOf(context);
+                final overlay = Overlay.of(context, rootOverlay: true);
                 final reservationNotifier = ref.read(
                   reservationActionProvider.notifier,
                 );
@@ -91,8 +93,9 @@ class LaundryStatusDialog extends ConsumerWidget {
                 navigator.pop();
 
                 try {
-                  final reservation = await reservationNotifier.reserve(
-                    machineId: machineId,
+                  final reservation = await runWithLoadingOverlay(
+                    overlay,
+                    () => reservationNotifier.reserve(machineId: machineId),
                   );
 
                   if (reservation == null) {
@@ -101,9 +104,7 @@ class LaundryStatusDialog extends ConsumerWidget {
                         .error;
                     messenger.showSnackBar(
                       SnackBar(
-                        content: Text(
-                          '예약 실패: ${reservationActionErrorMessage(error, fallback: '예약에 실패했습니다. 다시 시도해주세요.')}',
-                        ),
+                        content: Text(reserveFailureMessage(error)),
                       ),
                     );
                     return;

--- a/lib/core/ui/loading_overlay.dart
+++ b/lib/core/ui/loading_overlay.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+
+/// 비동기 작업이 진행되는 동안 화면 위에 로딩 인디케이터를 표시합니다.
+///
+/// 라우트가 아닌 루트 [Overlay] 위에 그려지므로, 다이얼로그를 닫은 직후처럼
+/// 호출부 컨텍스트가 사라지는 상황에서도 안전하게 동작합니다.
+Future<T> showLoadingWhile<T>(
+  BuildContext context,
+  Future<T> Function() action,
+) {
+  return runWithLoadingOverlay(
+    Overlay.of(context, rootOverlay: true),
+    action,
+  );
+}
+
+/// 미리 확보한 [OverlayState] 위에서 인디케이터를 표시하며 작업을 수행합니다.
+///
+/// 다이얼로그를 먼저 닫은 뒤 작업을 이어가는 경우, 닫기 전에 루트 오버레이를
+/// 캡처해 두고 이 함수에 넘기면 됩니다.
+Future<T> runWithLoadingOverlay<T>(
+  OverlayState overlay,
+  Future<T> Function() action,
+) async {
+  final entry = OverlayEntry(
+    builder: (_) => const _LoadingOverlay(),
+  );
+  overlay.insert(entry);
+  try {
+    return await action();
+  } finally {
+    entry.remove();
+  }
+}
+
+class _LoadingOverlay extends StatelessWidget {
+  const _LoadingOverlay();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Positioned.fill(
+      child: ColoredBox(
+        color: Color(0x66000000),
+        child: Center(child: CircularProgressIndicator()),
+      ),
+    );
+  }
+}

--- a/lib/core/ui/loading_overlay.dart
+++ b/lib/core/ui/loading_overlay.dart
@@ -22,14 +22,23 @@ Future<T> runWithLoadingOverlay<T>(
   OverlayState overlay,
   Future<T> Function() action,
 ) async {
+  // 호출 시점에 이미 오버레이가 해제됐다면 인디케이터 없이 작업만 수행합니다.
+  if (!overlay.mounted) {
+    return action();
+  }
+
   final entry = OverlayEntry(
-    builder: (_) => const _LoadingOverlay(),
+    builder: (_) => const Positioned.fill(child: _LoadingOverlay()),
   );
   overlay.insert(entry);
   try {
     return await action();
   } finally {
-    entry.remove();
+    // 작업 도중 화면 이탈 등으로 오버레이가 해제되면 remove가 StateError를
+    // 던지므로, 살아 있을 때만 제거합니다.
+    if (overlay.mounted) {
+      entry.remove();
+    }
   }
 }
 
@@ -38,11 +47,9 @@ class _LoadingOverlay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Positioned.fill(
-      child: ColoredBox(
-        color: Color(0x66000000),
-        child: Center(child: CircularProgressIndicator()),
-      ),
+    return const ColoredBox(
+      color: Color(0x66000000),
+      child: Center(child: CircularProgressIndicator()),
     );
   }
 }

--- a/lib/features/reservation/presentation/providers/reservation_action_provider.dart
+++ b/lib/features/reservation/presentation/providers/reservation_action_provider.dart
@@ -1,10 +1,17 @@
+import 'package:collection/collection.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:washer/core/utils/app_logger.dart';
 import 'package:washer/features/reservation/data/data_sources/remote/reservation_remote_data_source.dart';
+import 'package:washer/features/reservation/data/data_sources/remote/reservation_status_remote_data_source.dart';
 import 'package:washer/features/reservation/data/models/local/active_reservation_model.dart';
 import 'package:washer/features/reservation/presentation/providers/reservation_status_provider.dart';
 import 'package:washer/features/reservation/presentation/providers/reservation_sync_controller.dart';
+
+/// 예약 요청 직전 GET으로 확인한 결과, 이미 예약/사용 중이라 예약할 수 없는 경우.
+class AlreadyReservedException implements Exception {
+  const AlreadyReservedException();
+}
 
 class ReservationActionNotifier extends AsyncNotifier<ActiveReservationModel?> {
   Future<ActiveReservationModel?>? _reserveRequest;
@@ -27,6 +34,17 @@ class ReservationActionNotifier extends AsyncNotifier<ActiveReservationModel?> {
     state = const AsyncLoading();
 
     try {
+      // 예약 요청 전, 최신 기기 상태를 GET으로 불러와 예약 가능 여부를 비교합니다.
+      final latestStatus = await ref
+          .read(homeRemoteDataSourceProvider)
+          .getMachineStatus();
+      final targetMachine = latestStatus.machines.firstWhereOrNull(
+        (machine) => machine.machineId == machineId,
+      );
+      if (targetMachine != null && !targetMachine.isAvailable) {
+        throw const AlreadyReservedException();
+      }
+
       final startTime = DateTime.now().toIso8601String();
 
       final createdReservation = await ref
@@ -125,6 +143,14 @@ String reservationActionErrorMessage(
 
   return fallback;
 }
+
+/// 예약 시도 실패를 사용자에게 보여줄 문구로 변환합니다.
+///
+/// 사전 조회 단계에서 이미 예약/사용 중으로 확인된 경우는 별도 안내로,
+/// 그 외에는 서버 메시지(없으면 기본 문구)를 사용합니다.
+String reserveFailureMessage(Object? error) => error is AlreadyReservedException
+    ? '이미 예약된 기기입니다.'
+    : '예약 실패: ${reservationActionErrorMessage(error, fallback: '예약에 실패했습니다. 다시 시도해주세요.')}';
 
 final reservationActionProvider =
     AsyncNotifierProvider<ReservationActionNotifier, ActiveReservationModel?>(

--- a/lib/features/reservation/presentation/widgets/reservation_section_widget.dart
+++ b/lib/features/reservation/presentation/widgets/reservation_section_widget.dart
@@ -11,6 +11,7 @@ import 'package:washer/core/theme/color.dart';
 import 'package:washer/core/theme/icon.dart';
 import 'package:washer/core/theme/spacing.dart';
 import 'package:washer/core/theme/typography.dart';
+import 'package:washer/core/ui/loading_overlay.dart';
 import 'package:washer/core/utils/app_logger.dart';
 import 'package:washer/core/utils/room_formatter.dart';
 import 'package:washer/features/reservation/data/models/local/active_reservation_model.dart';
@@ -156,18 +157,19 @@ class _ReservationSectionWidgetState
 
   Future<void> _reserveMachine(BuildContext context, _MachineData item) async {
     try {
-      final reservation = await ref
-          .read(reservationActionProvider.notifier)
-          .reserve(machineId: item.machineId);
+      final reservation = await showLoadingWhile(
+        context,
+        () => ref
+            .read(reservationActionProvider.notifier)
+            .reserve(machineId: item.machineId),
+      );
 
       if (reservation == null) {
         if (context.mounted) {
           final error = ref.read(reservationActionProvider).error;
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
-              content: Text(
-                '예약 실패: ${reservationActionErrorMessage(error, fallback: '예약에 실패했습니다. 다시 시도해주세요.')}',
-              ),
+              content: Text(reserveFailureMessage(error)),
             ),
           );
         }

--- a/test/features/reservation/reservation_test.dart
+++ b/test/features/reservation/reservation_test.dart
@@ -338,6 +338,46 @@ void main() {
       ]);
     });
 
+    test('예약 전 조회 결과 이미 예약된 기기면 요청을 보내지 않고 예외를 담는다', () async {
+      final reservationDataSource = FakeReservationRemoteDataSource();
+      final container = ProviderContainer(
+        overrides: [
+          reservationRemoteDataSourceProvider.overrideWith(
+            (ref) => reservationDataSource,
+          ),
+          homeRemoteDataSourceProvider.overrideWith(
+            (ref) => FakeHomeRemoteDataSource(
+              machineStatusLoader: () async => const MachineStatusResponse(
+                machines: [
+                  MachineModel(
+                    machineId: 83,
+                    name: 'Washer-4F-L1',
+                    type: 'WASHER',
+                    status: 'NORMAL',
+                    availability: 'RESERVED',
+                    reservationId: 114,
+                  ),
+                ],
+                totalCount: 1,
+              ),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container
+          .read(reservationActionProvider.notifier)
+          .reserve(machineId: 83);
+
+      expect(result, isNull);
+      expect(reservationDataSource.lastMachineId, isNull);
+      expect(
+        container.read(reservationActionProvider).error,
+        isA<AlreadyReservedException>(),
+      );
+    });
+
     test('예약 취소 실패 시 서버 메시지를 상태에 담는다', () async {
       final error = DioException(
         requestOptions: RequestOptions(path: '/reservations/114'),


### PR DESCRIPTION
## 개요
Closes #210

예약 시 이미 예약/사용 중인 기기로 요청이 나가거나, 처리 중 피드백이 없어 중복 탭이 발생하던 문제를 개선합니다.

## 변경 사항
- **예약 사전 조회**: 예약 POST 전 최신 기기 상태를 GET으로 조회하여, 이미 예약/사용 중이면 요청을 보내지 않고 `AlreadyReservedException`으로 안내합니다.
- **로딩 인디케이터**: 루트 `Overlay` 기반 `loading_overlay`(`showLoadingWhile` / `runWithLoadingOverlay`)를 추가했습니다. 다이얼로그를 pop한 직후처럼 호출부 컨텍스트가 사라져도 안전하게 동작합니다.
- **중복 제거**: 예약 실패 안내 문구 분기를 `reserveFailureMessage` 헬퍼로 통합해 두 호출부의 중복을 제거했습니다.
- **테스트**: 사전 조회로 이미 예약된 기기면 요청을 보내지 않고 예외를 담는 케이스를 추가했습니다.

## 검증
- `flutter analyze` (변경 파일): No issues found
- `flutter test test/features/reservation/reservation_test.dart`: 12개 전부 통과