### PR TITLE
🔀 :: (#221) - 다이얼로그 액션 공통화 (팩토리 + 단일 실행기)

### DIFF
--- a/lib/core/ui/dialog/dialog_action.dart
+++ b/lib/core/ui/dialog/dialog_action.dart
@@ -65,8 +65,11 @@ Future<void> runDialogAction<R>(
 
     if (action.isSuccess(result)) {
       onSuccess?.call();
-      messenger.showSnackBar(SnackBar(content: Text(action.successMessage)));
-    } else {
+      // 비동기 작업 도중 화면이 이탈해 messenger가 해제됐을 수 있다.
+      if (messenger.mounted) {
+        messenger.showSnackBar(SnackBar(content: Text(action.successMessage)));
+      }
+    } else if (messenger.mounted) {
       messenger.showSnackBar(
         SnackBar(content: Text(action.failureMessage(container))),
       );
@@ -78,6 +81,8 @@ Future<void> runDialogAction<R>(
       error: error,
       stackTrace: stackTrace,
     );
-    messenger.showSnackBar(SnackBar(content: Text('오류: $error')));
+    if (messenger.mounted) {
+      messenger.showSnackBar(SnackBar(content: Text('오류: $error')));
+    }
   }
 }

--- a/lib/core/ui/dialog/dialog_action.dart
+++ b/lib/core/ui/dialog/dialog_action.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:washer/core/ui/loading_overlay.dart';
+import 'package:washer/core/utils/app_logger.dart';
+
+/// 다이얼로그/위젯에서 실행하는 비동기 액션 한 건의 정의.
+///
+/// "무엇을 실행하고, 성공/실패를 어떻게 판단하며, 어떤 메시지를 띄울지"라는
+/// 액션 고유 정보만 담는다. 액션 종류별 정의는 `DialogActions` 팩토리 한 곳에
+/// 모아 두고, 호출부는 그것을 [runDialogAction]에 넘기기만 한다.
+///
+/// [run]·[failureMessage]는 위젯의 `ref`가 아니라 lifecycle과 무관한
+/// [ProviderContainer]를 받는다. 따라서 pop(=widget dispose) 이후 실행돼도
+/// "bad state" 오류가 나지 않으며, 호출부가 notifier를 미리 캡처할 필요도 없다.
+class DialogAction<R> {
+  const DialogAction({
+    required this.run,
+    required this.isSuccess,
+    required this.successMessage,
+    required this.failureMessage,
+    required this.logName,
+    this.showLoading = false,
+  });
+
+  final Future<R> Function(ProviderContainer container) run;
+  final bool Function(R result) isSuccess;
+  final String successMessage;
+  final String Function(ProviderContainer container) failureMessage;
+  final String logName;
+
+  /// 작업 동안 루트 오버레이에 로딩 인디케이터를 표시할지 여부.
+  final bool showLoading;
+}
+
+/// [action]을 실행하고 결과 스낵바를 띄우는 공통 실행기.
+///
+/// await **이전에** messenger/navigator/container/overlay를 모두 캡처하므로
+/// pop·화면 이탈 이후에도 안전하다. 이 캡처 로직을 한곳에 모아 두는 것이 목적이며,
+/// 각 호출부가 따로 캡처하면 한 곳을 빠뜨려 bad state 오류가 재발하기 쉽다.
+///
+/// - [popFirst] : 호출 즉시 현재 라우트를 pop할지(다이얼로그면 true).
+/// - [onSuccess]: 성공 시 성공 스낵바 직전에 실행(예: 화면 이동). 네비게이션처럼
+///   context가 필요한 동작은 호출부에서 미리 캡처해 클로저로 넘긴다.
+Future<void> runDialogAction<R>(
+  BuildContext context,
+  DialogAction<R> action, {
+  bool popFirst = true,
+  VoidCallback? onSuccess,
+}) async {
+  final messenger = ScaffoldMessenger.of(context);
+  final navigator = Navigator.of(context);
+  final container = ProviderScope.containerOf(context);
+  final overlay = action.showLoading
+      ? Overlay.of(context, rootOverlay: true)
+      : null;
+
+  if (popFirst) {
+    navigator.pop();
+  }
+
+  try {
+    final result = overlay != null
+        ? await runWithLoadingOverlay(overlay, () => action.run(container))
+        : await action.run(container);
+
+    if (action.isSuccess(result)) {
+      onSuccess?.call();
+      messenger.showSnackBar(SnackBar(content: Text(action.successMessage)));
+    } else {
+      messenger.showSnackBar(
+        SnackBar(content: Text(action.failureMessage(container))),
+      );
+    }
+  } catch (error, stackTrace) {
+    AppLogger.error(
+      '${action.logName} 처리 중 오류가 발생했습니다.',
+      name: action.logName,
+      error: error,
+      stackTrace: stackTrace,
+    );
+    messenger.showSnackBar(SnackBar(content: Text('오류: $error')));
+  }
+}

--- a/lib/core/ui/dialog/dialog_actions.dart
+++ b/lib/core/ui/dialog/dialog_actions.dart
@@ -1,0 +1,68 @@
+import 'package:washer/core/constants/durations.dart';
+import 'package:washer/core/ui/dialog/dialog_action.dart';
+import 'package:washer/features/reservation/data/models/local/active_reservation_model.dart';
+import 'package:washer/features/reservation/presentation/providers/reservation_action_provider.dart';
+import 'package:washer/features/report/presentation/providers/report_provider.dart';
+
+/// 다이얼로그/위젯에서 쓰는 비동기 액션 정의 모음.
+///
+/// 액션의 provider 호출·성공 판정·메시지를 여기 한 곳에서만 정의한다.
+/// 동작이나 문구를 바꿀 때 이 파일만 고치면 모든 호출부에 반영된다.
+abstract final class DialogActions {
+  /// 기기 예약. 성공 시 생성된 예약 모델, 실패 시 null을 반환한다.
+  static DialogAction<ActiveReservationModel?> reserve({
+    required String machineName,
+    required int machineId,
+  }) {
+    return DialogAction<ActiveReservationModel?>(
+      run: (container) =>
+          container.read(reservationActionProvider.notifier).reserve(
+            machineId: machineId,
+          ),
+      isSuccess: (reservation) => reservation != null,
+      successMessage: '$machineName 예약이 완료되었습니다\n'
+          '$reservationExpiryMinutes분 동안 기기 연결을 확인합니다',
+      failureMessage: (container) => reserveFailureMessage(
+        container.read(reservationActionProvider).error,
+      ),
+      logName: 'ReserveAction',
+      showLoading: true,
+    );
+  }
+
+  /// 예약 취소.
+  static DialogAction<bool> cancelReservation({required int reservationId}) {
+    return DialogAction<bool>(
+      run: (container) =>
+          container.read(reservationActionProvider.notifier).cancel(
+            reservationId: reservationId,
+          ),
+      isSuccess: (didCancel) => didCancel,
+      successMessage: '예약이 취소되었습니다.',
+      failureMessage: (container) => reservationActionErrorMessage(
+        container.read(reservationActionProvider).error,
+        fallback: '예약 취소에 실패했습니다.',
+      ),
+      logName: 'CancelReservationAction',
+    );
+  }
+
+  /// 기기 고장 신고.
+  static DialogAction<bool> reportBroken({
+    required int machineId,
+    required String description,
+  }) {
+    return DialogAction<bool>(
+      run: (container) =>
+          container.read(reportProvider.notifier).createMalfunctionReport(
+            machineId: machineId,
+            description: description,
+          ),
+      isSuccess: (didReport) => didReport,
+      successMessage: '신고가 완료되었습니다.',
+      failureMessage: (container) =>
+          reportErrorMessage(container.read(reportProvider).error),
+      logName: 'ReportBrokenAction',
+    );
+  }
+}

--- a/lib/core/ui/dialog/laundry_action_dialog.dart
+++ b/lib/core/ui/dialog/laundry_action_dialog.dart
@@ -4,9 +4,9 @@ import 'package:washer/core/enums/laundry_action_type.dart';
 import 'package:washer/core/theme/color.dart';
 import 'package:washer/core/theme/spacing.dart';
 import 'package:washer/core/theme/typography.dart';
+import 'package:washer/core/ui/dialog/dialog_action.dart';
+import 'package:washer/core/ui/dialog/dialog_actions.dart';
 import 'package:washer/core/ui/dialog/washer_dialog.dart';
-import 'package:washer/core/utils/app_logger.dart';
-import 'package:washer/features/reservation/presentation/providers/reservation_action_provider.dart';
 
 class LaundryActionDialog extends ConsumerStatefulWidget {
   const LaundryActionDialog({
@@ -29,52 +29,25 @@ class LaundryActionDialog extends ConsumerStatefulWidget {
 
 class _LaundryActionDialogState extends ConsumerState<LaundryActionDialog> {
   Future<void> _handleConfirm() async {
-    final messenger = ScaffoldMessenger.of(context);
-    final navigator = Navigator.of(context);
-    final container = ProviderScope.containerOf(context);
-    final reservationNotifier = ref.read(reservationActionProvider.notifier);
-
-    try {
-      switch (widget.actionType) {
-        case LaundryActionType.reserve:
-          navigator.pop();
-          messenger.showSnackBar(
-            const SnackBar(
-              content: Text('예약 후 자동으로 기기 연결 확인이 진행됩니다.'),
-            ),
-          );
-          break;
-        case LaundryActionType.cancelReservation:
-          navigator.pop();
-          final didCancel = await reservationNotifier.cancel(
+    switch (widget.actionType) {
+      case LaundryActionType.reserve:
+        Navigator.of(context).pop();
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('예약 후 자동으로 기기 연결 확인이 진행됩니다.'),
+          ),
+        );
+        break;
+      case LaundryActionType.cancelReservation:
+        await runDialogAction(
+          context,
+          DialogActions.cancelReservation(
             reservationId: widget.reservationId,
-          );
-          messenger.showSnackBar(
-            SnackBar(
-              content: Text(
-                didCancel
-                    ? '예약이 취소되었습니다.'
-                    : reservationActionErrorMessage(
-                        container.read(reservationActionProvider).error,
-                        fallback: '예약 취소에 실패했습니다.',
-                      ),
-              ),
-            ),
-          );
-          break;
-        case LaundryActionType.reportBroken:
-          throw UnsupportedError('ReportBrokenDialog를 사용해주세요.');
-      }
-    } catch (error, stackTrace) {
-      AppLogger.error(
-        '세탁 액션 처리 중 오류가 발생했습니다.',
-        name: 'LaundryActionDialog',
-        error: error,
-        stackTrace: stackTrace,
-      );
-      messenger.showSnackBar(
-        SnackBar(content: Text('오류: $error')),
-      );
+          ),
+        );
+        break;
+      case LaundryActionType.reportBroken:
+        throw UnsupportedError('ReportBrokenDialog를 사용해주세요.');
     }
   }
 

--- a/lib/core/ui/dialog/laundry_action_dialog.dart
+++ b/lib/core/ui/dialog/laundry_action_dialog.dart
@@ -31,8 +31,11 @@ class _LaundryActionDialogState extends ConsumerState<LaundryActionDialog> {
   Future<void> _handleConfirm() async {
     switch (widget.actionType) {
       case LaundryActionType.reserve:
-        Navigator.of(context).pop();
-        ScaffoldMessenger.of(context).showSnackBar(
+        // pop 직후 context가 무효화될 수 있으므로 미리 캡처한다.
+        final navigator = Navigator.of(context);
+        final messenger = ScaffoldMessenger.of(context);
+        navigator.pop();
+        messenger.showSnackBar(
           const SnackBar(
             content: Text('예약 후 자동으로 기기 연결 확인이 진행됩니다.'),
           ),

--- a/lib/core/ui/dialog/laundry_status_dialog.dart
+++ b/lib/core/ui/dialog/laundry_status_dialog.dart
@@ -7,14 +7,13 @@ import 'package:washer/core/enums/laundry_status.dart';
 import 'package:washer/core/enums/machine_state.dart';
 import 'package:washer/core/theme/spacing.dart';
 import 'package:washer/core/theme/typography.dart';
+import 'package:washer/core/ui/dialog/dialog_action.dart';
+import 'package:washer/core/ui/dialog/dialog_actions.dart';
 import 'package:washer/core/ui/dialog/washer_dialog.dart';
-import 'package:washer/core/ui/loading_overlay.dart';
-import 'package:washer/core/utils/app_logger.dart';
 import 'package:washer/core/utils/date_time_formatter.dart';
 import 'package:washer/core/utils/room_formatter.dart';
 import 'package:washer/features/reservation/data/models/local/active_reservation_model.dart';
 import 'package:washer/features/reservation/presentation/providers/reservation_status_provider.dart';
-import 'package:washer/features/reservation/presentation/providers/reservation_action_provider.dart';
 
 class LaundryStatusDialog extends ConsumerWidget {
   const LaundryStatusDialog({
@@ -81,55 +80,13 @@ class LaundryStatusDialog extends ConsumerWidget {
         confirmText: isAvailable ? '예약하기' : '확인',
         backText: isAvailable ? '취소' : null,
         onConfirmPressed: isAvailable
-            ? () async {
-                final messenger = ScaffoldMessenger.of(context);
-                final navigator = Navigator.of(context);
-                final container = ProviderScope.containerOf(context);
-                final overlay = Overlay.of(context, rootOverlay: true);
-                final reservationNotifier = ref.read(
-                  reservationActionProvider.notifier,
-                );
-
-                navigator.pop();
-
-                try {
-                  final reservation = await runWithLoadingOverlay(
-                    overlay,
-                    () => reservationNotifier.reserve(machineId: machineId),
-                  );
-
-                  if (reservation == null) {
-                    final error = container
-                        .read(reservationActionProvider)
-                        .error;
-                    messenger.showSnackBar(
-                      SnackBar(
-                        content: Text(reserveFailureMessage(error)),
-                      ),
-                    );
-                    return;
-                  }
-
-                  messenger.showSnackBar(
-                    SnackBar(
-                      content: Text(
-                        '$machineName 예약이 완료되었습니다\n'
-                        '$reservationExpiryMinutes분 동안 기기 연결을 확인합니다',
-                      ),
-                    ),
-                  );
-                } catch (error, stackTrace) {
-                  AppLogger.error(
-                    '세탁 상태 다이얼로그 예약 처리 중 오류가 발생했습니다.',
-                    name: 'LaundryStatusDialog',
-                    error: error,
-                    stackTrace: stackTrace,
-                  );
-                  messenger.showSnackBar(
-                    SnackBar(content: Text('예약 실패: $error')),
-                  );
-                }
-              }
+            ? () => runDialogAction(
+                context,
+                DialogActions.reserve(
+                  machineName: machineName,
+                  machineId: machineId,
+                ),
+              )
             : null,
         content: Column(
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/report/presentation/widgets/report_broken_dialog.dart
+++ b/lib/features/report/presentation/widgets/report_broken_dialog.dart
@@ -4,9 +4,9 @@ import 'package:washer/core/theme/color.dart';
 import 'package:washer/core/theme/spacing.dart';
 import 'package:washer/core/theme/typography.dart';
 import 'package:washer/core/ui/circle_widget.dart';
+import 'package:washer/core/ui/dialog/dialog_action.dart';
+import 'package:washer/core/ui/dialog/dialog_actions.dart';
 import 'package:washer/core/ui/dialog/washer_dialog.dart';
-import 'package:washer/core/utils/app_logger.dart';
-import 'package:washer/features/report/presentation/providers/report_provider.dart';
 
 class ReportBrokenDialog extends ConsumerStatefulWidget {
   const ReportBrokenDialog({
@@ -41,45 +41,23 @@ class _ReportBrokenDialogState extends ConsumerState<ReportBrokenDialog> {
   }
 
   Future<void> _handleConfirm() async {
-    final messenger = ScaffoldMessenger.of(context);
-    final navigator = Navigator.of(context);
-    final container = ProviderScope.containerOf(context);
-    final reportNotifier = ref.read(reportProvider.notifier);
     final description = _textController.text.trim();
 
     if (description.isEmpty) {
       _focusNode.requestFocus();
-      messenger.showSnackBar(
+      ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('고장 내용을 입력해주세요.')),
       );
       return;
     }
 
-    try {
-      navigator.pop();
-      final didReport = await reportNotifier.createMalfunctionReport(
+    await runDialogAction(
+      context,
+      DialogActions.reportBroken(
         machineId: widget.machineId,
         description: description,
-      );
-
-      messenger.showSnackBar(
-        SnackBar(
-          content: Text(
-            didReport
-                ? '신고가 완료되었습니다.'
-                : reportErrorMessage(container.read(reportProvider).error),
-          ),
-        ),
-      );
-    } catch (error, stackTrace) {
-      AppLogger.error(
-        '고장 신고 다이얼로그 처리 중 오류가 발생했습니다.',
-        name: 'ReportBrokenDialog',
-        error: error,
-        stackTrace: stackTrace,
-      );
-      messenger.showSnackBar(SnackBar(content: Text('오류: $error')));
-    }
+      ),
+    );
   }
 
   @override

--- a/lib/features/reservation/presentation/widgets/reservation_section_widget.dart
+++ b/lib/features/reservation/presentation/widgets/reservation_section_widget.dart
@@ -2,7 +2,6 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
-import 'package:washer/core/constants/durations.dart';
 import 'package:washer/core/enums/laundry_machine_type.dart';
 import 'package:washer/core/enums/laundry_status.dart';
 import 'package:washer/core/enums/reservation_state.dart';
@@ -11,8 +10,8 @@ import 'package:washer/core/theme/color.dart';
 import 'package:washer/core/theme/icon.dart';
 import 'package:washer/core/theme/spacing.dart';
 import 'package:washer/core/theme/typography.dart';
-import 'package:washer/core/ui/loading_overlay.dart';
-import 'package:washer/core/utils/app_logger.dart';
+import 'package:washer/core/ui/dialog/dialog_action.dart';
+import 'package:washer/core/ui/dialog/dialog_actions.dart';
 import 'package:washer/core/utils/room_formatter.dart';
 import 'package:washer/features/reservation/data/models/local/active_reservation_model.dart';
 import 'package:washer/features/reservation/data/models/local/laundry_machine_model.dart';
@@ -156,50 +155,15 @@ class _ReservationSectionWidgetState
   }
 
   Future<void> _reserveMachine(BuildContext context, _MachineData item) async {
-    try {
-      final reservation = await showLoadingWhile(
-        context,
-        () => ref
-            .read(reservationActionProvider.notifier)
-            .reserve(machineId: item.machineId),
-      );
+    // router는 비동기 작업 전에 캡처해야 안전하다.
+    final router = GoRouter.of(context);
 
-      if (reservation == null) {
-        if (context.mounted) {
-          final error = ref.read(reservationActionProvider).error;
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(reserveFailureMessage(error)),
-            ),
-          );
-        }
-        return;
-      }
-
-      if (context.mounted) {
-        context.go(RoutePaths.home);
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(
-              '${item.name} 예약이 완료되었습니다\n'
-              '$reservationExpiryMinutes분 동안 기기 연결을 확인합니다',
-            ),
-          ),
-        );
-      }
-    } catch (error, stackTrace) {
-      AppLogger.error(
-        '예약 섹션 예약 처리 중 오류가 발생했습니다.',
-        name: 'ReservationSectionWidget',
-        error: error,
-        stackTrace: stackTrace,
-      );
-      if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('오류: $error')),
-        );
-      }
-    }
+    await runDialogAction(
+      context,
+      DialogActions.reserve(machineName: item.name, machineId: item.machineId),
+      popFirst: false,
+      onSuccess: () => router.go(RoutePaths.home),
+    );
   }
 
   void _showLaundryLayoutDialog(


### PR DESCRIPTION
## 개요

여러 다이얼로그/위젯에 흩어진 "비동기 액션 → pop → 결과 스낵바" 로직과 `ref` bad state 회피 코드를 공통화합니다.

이전에 4곳을 모두 고쳐야 했는데 `reservation_section_widget` 한 곳이 누락되어 옛 방식으로 남아 버그가 재발했고, `reserve` 액션 정의도 두 곳에 중복돼 있었습니다.

## 변경

- `DialogAction<R>` 디스크립터 + `runDialogAction` 단일 실행기 도입 (`core/ui/dialog/dialog_action.dart`)
  - await 이전에 messenger/navigator/container/overlay 캡처 → bad state 회피 일원화
  - 실행을 `ref`가 아닌 lifecycle 독립적인 `ProviderContainer` 기반으로 전환 → 호출부 notifier 수동 캡처 제거
- `DialogActions` 팩토리로 액션 정의 집약 (`reserve`/`cancelReservation`/`reportBroken`)
- 호출부 4곳 전환: `laundry_action_dialog`, `report_broken_dialog`, `laundry_status_dialog`, `reservation_section_widget`

## 효과

- 액션 동작/문구 변경 시 팩토리 한 파일만 수정
- bad state 회피 로직 단일화로 누락 재발 방지

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)