### PR TITLE
🔀 :: (#224) - 남은 시간 KST 파싱 오류 및 알람 삭제 후 미갱신 수정

### DIFF
--- a/lib/core/ui/dialog/laundry_status_dialog.dart
+++ b/lib/core/ui/dialog/laundry_status_dialog.dart
@@ -137,9 +137,9 @@ class LaundryStatusDialog extends ConsumerWidget {
     }
 
     if (isReserved) {
-      final reservedDateTime = reservedAt != null
-          ? DateTime.tryParse(reservedAt)
-          : null;
+      final reservedDateTime = DateTimeFormatter.parseServerDateTime(
+        reservedAt,
+      );
       final reservationExpiryTime = reservedDateTime?.add(
         reservationExpiryDuration,
       );

--- a/lib/core/utils/date_time_formatter.dart
+++ b/lib/core/utils/date_time_formatter.dart
@@ -1,10 +1,43 @@
 class DateTimeFormatter {
-  static String formatToShortDate(String? isoString) {
-    if (isoString == null) {
-      return '';
-    }
+  /// 한국 표준시 오프셋(UTC+9, 서머타임 없음).
+  static const Duration _kstOffset = Duration(hours: 9);
 
-    final parsed = DateTime.tryParse(isoString);
+  /// 서버는 타임존 표기가 없는 KST(`LocalDateTime`) 문자열을 보낸다.
+  /// (예: `2026-01-27T21:33:00` — `Z`도 `+09:00`도 없음)
+  ///
+  /// 오프셋이 없으면 `DateTime.parse`가 이를 기기 로컬 시간으로 해석해
+  /// KST가 아닌 기기에서 남은 시간이 어긋난다. 그래서 오프셋 표기가 없는
+  /// 문자열은 벽시계 숫자를 KST로 간주해 올바른 절대시각으로 변환한다.
+  /// 이미 오프셋이 있으면(SmartThings의 `...Z` 등) 그대로 신뢰한다.
+  static DateTime? parseServerDateTime(String? value) {
+    if (value == null) {
+      return null;
+    }
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      return null;
+    }
+    final parsed = DateTime.tryParse(trimmed);
+    // parsed.isUtc == true 이면 문자열에 오프셋 표기(Z 또는 ±hh:mm)가 있었던 것이므로
+    // 절대시각이 이미 정확하다. null(파싱 실패)도 그대로 넘긴다.
+    if (parsed == null || parsed.isUtc) {
+      return parsed;
+    }
+    // isUtc == false → 오프셋 표기 없음 → 벽시계 숫자를 KST로 해석한다.
+    return DateTime.utc(
+      parsed.year,
+      parsed.month,
+      parsed.day,
+      parsed.hour,
+      parsed.minute,
+      parsed.second,
+      parsed.millisecond,
+      parsed.microsecond,
+    ).subtract(_kstOffset);
+  }
+
+  static String formatToShortDate(String? isoString) {
+    final parsed = parseServerDateTime(isoString);
     if (parsed == null) {
       return '';
     }
@@ -13,10 +46,7 @@ class DateTimeFormatter {
   }
 
   static String formatToShortWithTime(String? isoString) {
-    if (isoString == null) {
-      return '';
-    }
-    final parsed = DateTime.tryParse(isoString);
+    final parsed = parseServerDateTime(isoString);
     if (parsed == null) {
       return '';
     }
@@ -69,7 +99,7 @@ class DateTimeFormatter {
     }
 
     final currentTime = now ?? DateTime.now();
-    final targetTime = DateTime.tryParse(trimmed);
+    final targetTime = parseServerDateTime(trimmed);
     final duration =
         targetTime?.difference(currentTime) ??
         _parseIsoDuration(trimmed) ??

--- a/lib/core/utils/date_time_formatter.dart
+++ b/lib/core/utils/date_time_formatter.dart
@@ -1,13 +1,11 @@
 class DateTimeFormatter {
-  /// 한국 표준시 오프셋(UTC+9, 서머타임 없음).
-  static const Duration _kstOffset = Duration(hours: 9);
-
   /// 서버는 타임존 표기가 없는 KST(`LocalDateTime`) 문자열을 보낸다.
   /// (예: `2026-01-27T21:33:00` — `Z`도 `+09:00`도 없음)
   ///
   /// 오프셋이 없으면 `DateTime.parse`가 이를 기기 로컬 시간으로 해석해
-  /// KST가 아닌 기기에서 남은 시간이 어긋난다. 그래서 오프셋 표기가 없는
-  /// 문자열은 벽시계 숫자를 KST로 간주해 올바른 절대시각으로 변환한다.
+  /// KST가 아닌 기기에서 남은 시간이 어긋난다. 그래서 오프셋 표기가 없으면
+  /// 문자열에 KST 오프셋(`+09:00`)을 붙여 파싱한다. 이러면 기기 로컬
+  /// 타임존이나 DST(서머타임) 여부와 무관하게 항상 올바른 절대시각을 얻는다.
   /// 이미 오프셋이 있으면(SmartThings의 `...Z` 등) 그대로 신뢰한다.
   static DateTime? parseServerDateTime(String? value) {
     if (value == null) {
@@ -17,23 +15,12 @@ class DateTimeFormatter {
     if (trimmed.isEmpty) {
       return null;
     }
-    final parsed = DateTime.tryParse(trimmed);
-    // parsed.isUtc == true 이면 문자열에 오프셋 표기(Z 또는 ±hh:mm)가 있었던 것이므로
-    // 절대시각이 이미 정확하다. null(파싱 실패)도 그대로 넘긴다.
-    if (parsed == null || parsed.isUtc) {
-      return parsed;
-    }
-    // isUtc == false → 오프셋 표기 없음 → 벽시계 숫자를 KST로 해석한다.
-    return DateTime.utc(
-      parsed.year,
-      parsed.month,
-      parsed.day,
-      parsed.hour,
-      parsed.minute,
-      parsed.second,
-      parsed.millisecond,
-      parsed.microsecond,
-    ).subtract(_kstOffset);
+    // 시간 성분(T) 뒤에 오프셋(Z 또는 ±hh:mm)이 붙어 있는지로 판단한다.
+    // (날짜의 `-`를 오프셋으로 오인하지 않도록 T 뒤만 본다.)
+    final hasTimeZone =
+        trimmed.endsWith('Z') ||
+        RegExp(r'T.*[+-]\d{2}(?::?\d{2})?$').hasMatch(trimmed);
+    return DateTime.tryParse(hasTimeZone ? trimmed : '$trimmed+09:00');
   }
 
   static String formatToShortDate(String? isoString) {

--- a/lib/features/alarm/presentation/providers/alarm_provider.dart
+++ b/lib/features/alarm/presentation/providers/alarm_provider.dart
@@ -43,16 +43,21 @@ class AlarmNotifier extends Notifier<AlarmState> {
     }
   }
 
-  /// 알림 화면을 벗어날 때 서버의 모든 알림을 삭제하고 로컬 상태를 비운다.
-  /// 다음에 화면을 다시 열면 새로 불러오도록 로드 플래그도 초기화한다.
+  /// 알림 화면을 벗어날 때 서버의 모든 알림을 삭제하고, 서버에서 목록을
+  /// 다시 불러와 상태(=뱃지)를 서버 기준으로 동기화한다.
+  ///
+  /// 로컬 상태를 임의로 비우지 않고 refetch하므로 삭제가 실패해도 UI가
+  /// 실제 서버 상태와 어긋나지 않는다.
+  /// (deleteAllNotifications는 내부에서 예외를 삼키므로 throw하지 않는다.)
   Future<void> clearAllOnLeave() async {
     if (state.alarms.isEmpty) {
       return;
     }
 
     await ref.read(alarmRepositoryProvider).deleteAllNotifications();
+    await fetchAlarmList(force: true);
+    // 다음에 화면을 다시 열면 또 새로 불러오도록 로드 플래그를 초기화한다.
     _hasLoaded = false;
-    state = const AlarmState();
   }
 }
 

--- a/lib/features/home/presentation/widgets/home_body_widget.dart
+++ b/lib/features/home/presentation/widgets/home_body_widget.dart
@@ -32,6 +32,9 @@ class _HomeBodyWidgetState extends ConsumerState<HomeBodyWidget>
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       ref.read(activeReservationProvider.notifier).ensureLoaded();
+      // 앱/홈 진입 시 알람을 불러와 알림 뱃지를 갱신한다.
+      // (force=false라 이미 로드됐으면 중복 호출하지 않는다.)
+      ref.read(alarmProvider.notifier).fetchAlarmList();
     });
   }
 

--- a/lib/features/home/presentation/widgets/home_my_reservation_widget.dart
+++ b/lib/features/home/presentation/widgets/home_my_reservation_widget.dart
@@ -361,9 +361,7 @@ class _ReservationExpiryText extends ConsumerWidget {
     final now = ref.watch(clockProvider).asData?.value ?? DateTime.now();
     var countdown = remainDuration ?? '만료됨';
 
-    final reservedTime = reservedAt != null
-        ? DateTime.tryParse(reservedAt!)
-        : null;
+    final reservedTime = DateTimeFormatter.parseServerDateTime(reservedAt);
     if (reservedTime != null) {
       countdown = _formatDuration(
         reservedTime.add(reservationExpiryDuration).difference(now),

--- a/lib/features/reservation/presentation/widgets/reservation_widget.dart
+++ b/lib/features/reservation/presentation/widgets/reservation_widget.dart
@@ -443,9 +443,7 @@ class _ReservedByMeCountdownText extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final now = ref.watch(clockProvider).asData?.value ?? DateTime.now();
-    final reservedTime = reservedAt != null
-        ? DateTime.tryParse(reservedAt!)
-        : null;
+    final reservedTime = DateTimeFormatter.parseServerDateTime(reservedAt);
     final expireAt = reservedTime?.add(reservationExpiryDuration);
 
     return Text(

--- a/test/core/core_test.dart
+++ b/test/core/core_test.dart
@@ -25,6 +25,40 @@ void main() {
     });
   });
 
+  group('DateTimeFormatter.parseServerDateTime', () {
+    test('treats offset-less server time as KST (UTC+9)', () {
+      // 서버 LocalDateTime: 오프셋 없음 → KST 벽시계로 해석 → UTC instant는 -9h
+      final parsed = DateTimeFormatter.parseServerDateTime(
+        '2026-01-27T21:33:00',
+      );
+      expect(parsed!.toUtc().toIso8601String(), '2026-01-27T12:33:00.000Z');
+    });
+
+    test('keeps absolute instant when offset/Z is present (SmartThings)', () {
+      final utc = DateTimeFormatter.parseServerDateTime(
+        '2026-01-27T21:33:00Z',
+      );
+      expect(utc!.toUtc().toIso8601String(), '2026-01-27T21:33:00.000Z');
+
+      final kst = DateTimeFormatter.parseServerDateTime(
+        '2026-01-27T21:33:00+09:00',
+      );
+      expect(kst!.toUtc().toIso8601String(), '2026-01-27T12:33:00.000Z');
+    });
+
+    test('remaining time uses absolute instant, not device wall clock', () {
+      // now = 12:00Z(= 21:00 KST), 완료예정 = 21:40 KST(오프셋 없는 서버 값) → 40분
+      final now = DateTime.utc(2026, 1, 27, 12, 0, 0);
+      expect(
+        DateTimeFormatter.formatRemainingTimeToKorean(
+          '2026-01-27T21:40:00',
+          now: now,
+        ),
+        '40분 00초',
+      );
+    });
+  });
+
   group('DateTimeFormatter.formatRemainingTimeToKorean', () {
     test('formats future ISO datetime relative to now', () {
       final now = DateTime.utc(2026, 3, 26, 12, 0, 0);


### PR DESCRIPTION
## 개요
#224 — 두 가지 버그를 함께 수정합니다.

### 1. 남은 세탁/건조 시간 +9시간 부풀림 (시간 포맷팅)
- 서버가 완료 예정 시각을 오프셋 없는 `LocalDateTime`(예: `2026-01-27T21:33:00`)으로 내려주는데, `DateTime.parse`가 이를 기기 로컬로 해석해 KST가 아닌 기기/에뮬레이터에서 절대시각이 +9h 어긋났습니다.
- `DateTimeFormatter.parseServerDateTime` 추가: 오프셋 표기가 없는(`isUtc==false`) 문자열만 KST로 재해석하고, `Z`/`+09:00`(SmartThings 등)은 그대로 신뢰. 서버 시각을 파싱하던 지점(`formatToShortDate`/`formatToShortWithTime`/`formatRemainingTimeToKorean` 및 위젯의 `reservedAt` 파싱)을 이 헬퍼로 통일.

### 2. 알람 삭제 후 미갱신 / 진입 시 뱃지 미표시
- 화면 이탈 시 전체 삭제 후 로컬 state만 비우던 것을 **서버 refetch**로 변경 → UI/뱃지를 서버 기준으로 동기화(삭제 실패해도 어긋나지 않음).
- 홈 진입 시 알람을 불러와 pull-to-refresh 이전에도 알림 뱃지가 표시되도록 보강.

## 테스트
- `flutter analyze` 클린
- `flutter test` 전체 통과(27개). `parseServerDateTime` KST/Z/offset 처리 및 남은 시간 계산에 대한 단위 테스트 3개 추가(기기 타임존과 무관하게 통과하도록 `now`를 명시 UTC로 지정).

## 참고
- 근본적으로는 서버가 `+09:00`/`Z`를 포함해 내려주는 것이 정석입니다. 그 경우 `parseServerDateTime`는 `isUtc==true` 경로로 자동 통과되어 클라이언트 보정과 충돌 없이 공존하고, 추후 헬퍼 제거도 가능합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
