### PR TITLE
🔀 :: (#228) - 세탁기/건조기 운전중 판정을 서버 값으로 복원

### DIFF
--- a/lib/features/reservation/data/models/local/laundry_machine_model.dart
+++ b/lib/features/reservation/data/models/local/laundry_machine_model.dart
@@ -100,18 +100,19 @@ abstract class MachineModel with _$MachineModel {
 
   bool get isUnavailable => normalizedStatus != 'NORMAL';
 
-  bool get isReserved => hasReservation || normalizedAvailability == 'RESERVED';
+  // 운전 중이면 reservationId가 남아있어도 예약이 아니라 사용 중으로 본다.
+  bool get isReserved =>
+      !isUnavailable &&
+      !isInUse &&
+      (hasReservation || normalizedAvailability == 'RESERVED');
 
   // 운전중 판정은 서버 availability 기준. (#228: SmartThings operatingState 판정 제거)
   // AVAILABLE=미사용, RESERVED=예약, 그 외(UNAVAILABLE)=운전중.
   // 남은 시간 카운트다운은 계속 SmartThings expectedCompletionTime 오버레이를 사용한다.
-  bool get isInUse {
-    if (isUnavailable) {
-      return false;
-    }
-
-    return normalizedAvailability != 'AVAILABLE' && !isReserved;
-  }
+  bool get isInUse =>
+      !isUnavailable &&
+      normalizedAvailability != 'AVAILABLE' &&
+      normalizedAvailability != 'RESERVED';
 
   // 예약 가능 = 고장 아님 + 예약 안 됨 + 사용 중 아님.
   bool get isAvailable => !isUnavailable && !isReserved && !isInUse;

--- a/lib/features/reservation/data/models/local/laundry_machine_model.dart
+++ b/lib/features/reservation/data/models/local/laundry_machine_model.dart
@@ -98,30 +98,23 @@ abstract class MachineModel with _$MachineModel {
 
   bool get hasReservation => (reservationId ?? 0) > 0;
 
-  bool get isAvailable =>
-      normalizedAvailability == 'AVAILABLE' && !hasReservation;
-
   bool get isUnavailable => normalizedStatus != 'NORMAL';
 
   bool get isReserved => hasReservation || normalizedAvailability == 'RESERVED';
 
+  // 운전중 판정은 서버 availability 기준. (#228: SmartThings operatingState 판정 제거)
+  // AVAILABLE=미사용, RESERVED=예약, 그 외(UNAVAILABLE)=운전중.
+  // 남은 시간 카운트다운은 계속 SmartThings expectedCompletionTime 오버레이를 사용한다.
   bool get isInUse {
-    if (isUnavailable || isAvailable) {
+    if (isUnavailable) {
       return false;
     }
 
-    final currentState = machineState;
-    if (currentState != null) {
-      return currentState != MachineState.delayWash &&
-          currentState != MachineState.none &&
-          currentState != MachineState.stop &&
-          currentState != MachineState.finished;
-    }
-
-    // 서버가 operatingState 없이 예약 불가 상태만 내려주는 경우가 있습니다.
-    // 이때 reservationId도 없으면 "예약 중"이 아니라 실제 "사용 중"으로 간주합니다.
-    return !hasReservation;
+    return normalizedAvailability != 'AVAILABLE' && !isReserved;
   }
+
+  // 예약 가능 = 고장 아님 + 예약 안 됨 + 사용 중 아님.
+  bool get isAvailable => !isUnavailable && !isReserved && !isInUse;
 }
 
 @freezed

--- a/lib/features/reservation/presentation/widgets/reservation_widget.dart
+++ b/lib/features/reservation/presentation/widgets/reservation_widget.dart
@@ -119,7 +119,8 @@ class ReservationWidget extends StatelessWidget {
           ),
           // 예약 가능 상태는 하단 버튼 줄에 히스토리 아이콘이 이미 있다.
           // 그 외(사용중/예약됨/고장) 상태에서도 하단 오른쪽에 히스토리 아이콘을 노출한다.
-          if (reservationState != ReservationState.available) ...[
+          // machineId가 유효할 때만(0이면 잘못된 조회 방지) 노출한다.
+          if (reservationState != ReservationState.available && machineId > 0) ...[
             AppGap.v8,
             Align(
               alignment: Alignment.centerRight,

--- a/lib/features/reservation/presentation/widgets/reservation_widget.dart
+++ b/lib/features/reservation/presentation/widgets/reservation_widget.dart
@@ -117,6 +117,18 @@ class ReservationWidget extends StatelessWidget {
             showActions: showActions,
             onReserve: onReserve,
           ),
+          // 예약 가능 상태는 하단 버튼 줄에 히스토리 아이콘이 이미 있다.
+          // 그 외(사용중/예약됨/고장) 상태에서도 하단 오른쪽에 히스토리 아이콘을 노출한다.
+          if (reservationState != ReservationState.available) ...[
+            AppGap.v8,
+            Align(
+              alignment: Alignment.centerRight,
+              child: _HistoryIconButton(
+                machineId: machineId,
+                machineName: machineName,
+              ),
+            ),
+          ],
         ],
       ),
     );
@@ -341,24 +353,42 @@ class _AvailableBottom extends StatelessWidget {
               },
             ),
             AppGap.h8,
-            WasherIconButton(
-              type: WasherIconType.historyCircle,
-              color: WasherColor.baseGray300,
-              size: 33,
-              padding: EdgeInsets.zero,
-              onTap: () {
-                showDialog(
-                  context: context,
-                  builder: (context) => HistoryDialog(
-                    machineId: machineId,
-                    machineName: machineName,
-                  ),
-                );
-              },
+            _HistoryIconButton(
+              machineId: machineId,
+              machineName: machineName,
             ),
           ],
         ),
       ],
+    );
+  }
+}
+
+class _HistoryIconButton extends StatelessWidget {
+  const _HistoryIconButton({
+    required this.machineId,
+    required this.machineName,
+  });
+
+  final int machineId;
+  final String machineName;
+
+  @override
+  Widget build(BuildContext context) {
+    return WasherIconButton(
+      type: WasherIconType.historyCircle,
+      color: WasherColor.baseGray300,
+      size: 33,
+      padding: EdgeInsets.zero,
+      onTap: () {
+        showDialog(
+          context: context,
+          builder: (context) => HistoryDialog(
+            machineId: machineId,
+            machineName: machineName,
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,10 +15,11 @@ import 'core/router/app_router.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await AppEnvironment.initialize();
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
+  // 서로 독립적인 초기화는 병렬로 처리한다.
+  await Future.wait([
+    AppEnvironment.initialize(),
+    Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform),
+  ]);
   if (kDebugMode) {
     await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(false);
   }

--- a/lib/splash_screen.dart
+++ b/lib/splash_screen.dart
@@ -31,11 +31,13 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
   }
 
   Future<void> _bootstrap() async {
-    if (await _handleForceUpdate()) {
-      return;
-    }
-
     final storage = ref.read(secureStorageProvider);
+
+    // 버전 체크(스토어 조회)를 먼저 시작해 사용자 조회와 병렬로 진행한다.
+    final versionStatusFuture = ref
+        .read(versionCheckServiceProvider)
+        .fetchUpdatableStatus();
+
     final accessToken = await storage.read(key: 'access_token');
     final refreshToken = await storage.read(key: 'refresh_token');
     final hasAccessToken = accessToken != null && accessToken.isNotEmpty;
@@ -44,20 +46,41 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
         refreshToken.isNotEmpty &&
         !TokenUtils.isExpired(refreshToken);
 
-    if (!hasAccessToken && !hasRefreshToken) {
-      await _goToLogin(storage);
+    final needsLogin =
+        (!hasAccessToken && !hasRefreshToken) ||
+        (hasAccessToken &&
+            TokenUtils.isExpired(accessToken) &&
+            !hasRefreshToken);
+
+    // 로그인 상태면 사용자 조회도 버전 체크와 병렬로 시작한다.
+    final myUserFuture = needsLogin
+        ? null
+        : ref.read(userRemoteDataSourceProvider).getMyUser();
+
+    // 강제 업데이트가 필요하면 팝업을 띄우고 이후 진입을 중단한다.
+    final versionStatus = await versionStatusFuture;
+    if (versionStatus != null) {
+      myUserFuture?.ignore(); // 병렬 조회 결과는 버린다(미처리 에러 방지).
+      if (!mounted) return;
+      await showDialog<void>(
+        context: context,
+        barrierDismissible: false,
+        builder: (_) => ForceUpdateDialog(
+          onUpdatePressed: () => ref
+              .read(versionCheckServiceProvider)
+              .openStore(versionStatus.appStoreLink),
+        ),
+      );
       return;
     }
 
-    if (hasAccessToken &&
-        TokenUtils.isExpired(accessToken) &&
-        !hasRefreshToken) {
+    if (myUserFuture == null) {
       await _goToLogin(storage);
       return;
     }
 
     try {
-      final myUser = await ref.read(userRemoteDataSourceProvider).getMyUser();
+      final myUser = await myUserFuture;
       ref.read(myUserProvider.notifier).setUser(myUser);
       if (!mounted) return;
       context.go(RoutePaths.home);
@@ -102,32 +125,6 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
     ref.read(myUserProvider.notifier).clear();
     if (!mounted) return;
     context.go(RoutePaths.login);
-  }
-
-  /// 앱이 최신 버전이 아니면 강제 업데이트 팝업을 띄운다.
-  ///
-  /// 업데이트가 필요해 팝업을 노출한 경우 `true`를 반환하여
-  /// 이후 초기화(인증/홈 진입)를 중단시킨다.
-  Future<bool> _handleForceUpdate() async {
-    final versionCheckService = ref.read(versionCheckServiceProvider);
-    final status = await versionCheckService.fetchUpdatableStatus();
-
-    if (status == null) {
-      return false;
-    }
-
-    if (!mounted) return true;
-
-    final storeLink = status.appStoreLink;
-    await showDialog<void>(
-      context: context,
-      barrierDismissible: false,
-      builder: (_) => ForceUpdateDialog(
-        onUpdatePressed: () => versionCheckService.openStore(storeLink),
-      ),
-    );
-
-    return true;
   }
 
   @override

--- a/lib/splash_screen.dart
+++ b/lib/splash_screen.dart
@@ -57,10 +57,14 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
         ? null
         : ref.read(userRemoteDataSourceProvider).getMyUser();
 
+    // 버전 체크를 기다리는 동안 사용자 조회에서 에러가 나도 미처리 async 에러로
+    // 보고되지 않도록 즉시 ignore()를 등록한다. 이후 await 시에는 에러가 그대로
+    // 던져져 try/catch에서 처리된다.
+    myUserFuture?.ignore();
+
     // 강제 업데이트가 필요하면 팝업을 띄우고 이후 진입을 중단한다.
     final versionStatus = await versionStatusFuture;
     if (versionStatus != null) {
-      myUserFuture?.ignore(); // 병렬 조회 결과는 버린다(미처리 에러 방지).
       if (!mounted) return;
       await showDialog<void>(
         context: context,

--- a/test/features/reservation/reservation_test.dart
+++ b/test/features/reservation/reservation_test.dart
@@ -155,7 +155,8 @@ void main() {
       expect(model.isInUse, isTrue);
     });
 
-    test('treats finished machine as not in use', () {
+    test('server UNAVAILABLE stays in use even if SmartThings reports finished', () {
+      // #228: 운전중 판정은 서버 availability가 기준. operatingState는 판정에 쓰지 않는다.
       const model = MachineModel(
         machineId: 1,
         name: 'Dryer-4F-R2',
@@ -165,8 +166,24 @@ void main() {
         operatingState: 'FINISHED',
       );
 
-      expect(model.machineState, MachineState.finished);
+      expect(model.isInUse, isTrue);
+      expect(model.isAvailable, isFalse);
+    });
+
+    test('server AVAILABLE is reservable even if SmartThings reports running', () {
+      // #228: availability가 AVAILABLE이면 예약 가능. operatingState는 무시한다.
+      const model = MachineModel(
+        machineId: 1,
+        name: 'Washer-3F-L1',
+        type: 'WASHER',
+        status: 'NORMAL',
+        availability: 'AVAILABLE',
+        operatingState: 'RUN',
+      );
+
       expect(model.isInUse, isFalse);
+      expect(model.isReserved, isFalse);
+      expect(model.isAvailable, isTrue);
     });
 
     test(


### PR DESCRIPTION
## 개요
운전중 여부(`isInUse`) 판정을 SmartThings `operatingState`에서 **서버 `availability` 기준**으로 복원합니다. (#223 부분 롤백)

Closes #228

> ⚠️ base가 `main`이라 그동안 develop 라인에 머지된 히스토리(#223 SmartThings 직접조회, KST 시간 수정 등)도 함께 포함됩니다. 핵심 변경은 아래 #228 커밋입니다.

## 변경 (#228)
- `MachineModel.isInUse`: SmartThings `machineState` 분기 제거, 서버 `availability`로 판정
  - `AVAILABLE`=미사용, `RESERVED`=예약, 그 외(`UNAVAILABLE`)=운전중
- 남은 시간 카운트다운은 계속 SmartThings `expectedCompletionTime` 오버레이 사용 (범위: 운전중 판정만 서버로)
- `machineState` getter는 home 화면 표시용으로 유지

## 테스트
- SmartThings 기반 `isInUse` 테스트 2건을 서버 기준으로 교체 (operatingState가 판정에 관여하지 않음을 양방향 검증)
- `flutter test test/features/reservation/` 전체 통과, analyze 이슈 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)