### PR TITLE
🔀 :: (#230) - 예약 취소 패널티 기간 중 요청 클라이언트 차단

### DIFF
--- a/lib/features/reservation/data/data_sources/remote/reservation_remote_data_source.dart
+++ b/lib/features/reservation/data/data_sources/remote/reservation_remote_data_source.dart
@@ -4,6 +4,7 @@ import 'package:retrofit/retrofit.dart';
 import 'package:washer/core/network/api_response_parser.dart';
 import 'package:washer/core/network/dio_client.dart';
 import 'package:washer/features/reservation/data/models/local/active_reservation_model.dart';
+import 'package:washer/features/reservation/data/models/remote/cancel_reservation_response.dart';
 import 'package:washer/features/reservation/data/models/remote/confirm_reservation_response.dart';
 
 part 'reservation_remote_data_source.g.dart';
@@ -14,7 +15,7 @@ abstract class ReservationRemoteDataSource {
     required String startTime,
   });
 
-  Future<void> cancelReservation({
+  Future<CancelReservationResponse> cancelReservation({
     required int id,
   });
 
@@ -61,10 +62,13 @@ class ReservationRemoteDataSourceImpl implements ReservationRemoteDataSource {
   }
 
   @override
-  Future<void> cancelReservation({
+  Future<CancelReservationResponse> cancelReservation({
     required int id,
   }) async {
-    await _api.cancelReservation(id);
+    final response = await _api.cancelReservation(id);
+    final data = castJsonMap(response.data);
+
+    return CancelReservationResponse.fromJson(data);
   }
 
   @override

--- a/lib/features/reservation/presentation/providers/reservation_action_provider.dart
+++ b/lib/features/reservation/presentation/providers/reservation_action_provider.dart
@@ -1,16 +1,27 @@
+import 'dart:async';
+
 import 'package:collection/collection.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:washer/core/utils/app_logger.dart';
+import 'package:washer/core/utils/date_time_formatter.dart';
 import 'package:washer/features/reservation/data/data_sources/remote/reservation_remote_data_source.dart';
 import 'package:washer/features/reservation/data/data_sources/remote/reservation_status_remote_data_source.dart';
 import 'package:washer/features/reservation/data/models/local/active_reservation_model.dart';
+import 'package:washer/features/reservation/presentation/providers/reservation_penalty_provider.dart';
 import 'package:washer/features/reservation/presentation/providers/reservation_status_provider.dart';
 import 'package:washer/features/reservation/presentation/providers/reservation_sync_controller.dart';
 
 /// 예약 요청 직전 GET으로 확인한 결과, 이미 예약/사용 중이라 예약할 수 없는 경우.
 class AlreadyReservedException implements Exception {
   const AlreadyReservedException();
+}
+
+/// 취소 패널티 기간이라 서버 요청 없이 클라이언트에서 예약을 막은 경우.
+class ReservationPenaltyException implements Exception {
+  const ReservationPenaltyException(this.expiresAt);
+
+  final DateTime expiresAt;
 }
 
 class ReservationActionNotifier extends AsyncNotifier<ActiveReservationModel?> {
@@ -34,6 +45,16 @@ class ReservationActionNotifier extends AsyncNotifier<ActiveReservationModel?> {
     state = const AsyncLoading();
 
     try {
+      // 취소 패널티 기간이면 서버로 요청을 보내지 않고 클라이언트에서 곧바로 막는다.
+      final penaltyExpiry = await ref.read(reservationPenaltyProvider.future);
+      if (penaltyExpiry != null) {
+        if (DateTime.now().isBefore(penaltyExpiry)) {
+          throw ReservationPenaltyException(penaltyExpiry);
+        }
+        // 이미 만료된 패널티면 정리만 하고 정상 진행한다.
+        unawaited(ref.read(reservationPenaltyProvider.notifier).clear());
+      }
+
       // 예약 요청 전, 최신 기기 상태를 GET으로 불러와 예약 가능 여부를 비교합니다.
       final latestStatus = await ref
           .read(homeRemoteDataSourceProvider)
@@ -85,9 +106,21 @@ class ReservationActionNotifier extends AsyncNotifier<ActiveReservationModel?> {
     try {
       ref.read(reservationSyncControllerProvider).stopPolling();
 
-      await ref
+      final result = await ref
           .read(reservationRemoteDataSourceProvider)
           .cancelReservation(id: reservationId);
+
+      // 패널티가 부과됐으면 만료시각을 로컬에 저장해, 이후 예약 시도를 클라에서 막는다.
+      if (result.penaltyApplied) {
+        final expiry = DateTimeFormatter.parseServerDateTime(
+          result.penaltyExpiresAt,
+        );
+        if (expiry != null) {
+          // build()이 끝난 뒤 기록해야 저장한 상태가 build 결과로 덮이지 않는다.
+          await ref.read(reservationPenaltyProvider.future);
+          await ref.read(reservationPenaltyProvider.notifier).record(expiry);
+        }
+      }
 
       await refreshReservationStatusProviders(ref);
 
@@ -148,9 +181,19 @@ String reservationActionErrorMessage(
 ///
 /// 사전 조회 단계에서 이미 예약/사용 중으로 확인된 경우는 별도 안내로,
 /// 그 외에는 서버 메시지(없으면 기본 문구)를 사용합니다.
-String reserveFailureMessage(Object? error) => error is AlreadyReservedException
-    ? '이미 예약된 기기입니다.'
-    : '예약 실패: ${reservationActionErrorMessage(error, fallback: '예약에 실패했습니다. 다시 시도해주세요.')}';
+String reserveFailureMessage(Object? error) {
+  if (error is ReservationPenaltyException) {
+    final remaining = error.expiresAt.difference(DateTime.now());
+    final minutes = remaining.inMinutes;
+    return minutes >= 1
+        ? '예약이 제한된 상태입니다. 약 $minutes분 후 다시 시도해주세요.'
+        : '예약이 제한된 상태입니다. 잠시 후 다시 시도해주세요.';
+  }
+  if (error is AlreadyReservedException) {
+    return '이미 예약된 기기입니다.';
+  }
+  return '예약 실패: ${reservationActionErrorMessage(error, fallback: '예약에 실패했습니다. 다시 시도해주세요.')}';
+}
 
 final reservationActionProvider =
     AsyncNotifierProvider<ReservationActionNotifier, ActiveReservationModel?>(

--- a/lib/features/reservation/presentation/providers/reservation_penalty_provider.dart
+++ b/lib/features/reservation/presentation/providers/reservation_penalty_provider.dart
@@ -2,35 +2,62 @@ import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:washer/core/network/dio_client.dart';
+import 'package:washer/core/utils/app_logger.dart';
 
 /// 예약 취소 패널티 만료시각을 로컬에 보관한다.
 ///
 /// 패널티 기간에는 서버가 예약 요청을 거부하므로, 만료시각을 저장해 두고
 /// 그 사이의 예약 시도는 서버로 보내지 않고 클라이언트에서 곧바로 막는다.
 /// 앱을 재시작해도 유지되도록 secure storage에 영속화한다.
+///
+/// secure storage는 기기 환경(Android Keystore, iOS Keychain 등)에 따라 예외를
+/// 던질 수 있다. 저장소 실패가 예약/취소 흐름을 깨지 않도록 모든 저장소 접근을
+/// 이 클래스 안에서 방어적으로 처리한다.
 class ReservationPenaltyNotifier extends AsyncNotifier<DateTime?> {
   static const _storageKey = 'reservation_penalty_expires_at';
 
   @override
   Future<DateTime?> build() async {
-    final raw = await ref.read(secureStorageProvider).read(key: _storageKey);
-    final expiry = raw == null ? null : DateTime.tryParse(raw);
+    try {
+      final raw = await ref.read(secureStorageProvider).read(key: _storageKey);
+      final expiry = raw == null ? null : DateTime.tryParse(raw);
 
-    // 저장된 값이 없거나 이미 만료됐으면 정리하고 없는 상태로 시작한다.
-    if (expiry == null || !DateTime.now().isBefore(expiry)) {
-      if (raw != null) {
-        unawaited(_delete());
+      // 저장된 값이 없거나 이미 만료됐으면 정리하고 없는 상태로 시작한다.
+      if (expiry == null || !DateTime.now().isBefore(expiry)) {
+        if (raw != null) {
+          unawaited(_delete());
+        }
+        return null;
       }
+      return expiry;
+    } catch (error, stackTrace) {
+      AppLogger.error(
+        '패널티 만료 시각을 불러오는 중 오류가 발생했습니다.',
+        name: 'ReservationPenaltyNotifier',
+        error: error,
+        stackTrace: stackTrace,
+      );
       return null;
     }
-    return expiry;
   }
 
   /// 서버가 알려준 패널티 만료시각을 저장한다.
+  ///
+  /// 저장소 쓰기가 실패하더라도 서버가 이미 부과한 패널티이므로, 최소한 현재
+  /// 세션 동안은 차단이 유지되도록 상태는 항상 갱신한다.
   Future<void> record(DateTime expiresAt) async {
-    await ref
-        .read(secureStorageProvider)
-        .write(key: _storageKey, value: expiresAt.toIso8601String());
+    try {
+      await ref
+          .read(secureStorageProvider)
+          .write(key: _storageKey, value: expiresAt.toIso8601String());
+    } catch (error, stackTrace) {
+      AppLogger.error(
+        '패널티 만료 시각을 기록하는 중 오류가 발생했습니다.',
+        name: 'ReservationPenaltyNotifier',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
     state = AsyncData(expiresAt);
   }
 
@@ -40,8 +67,18 @@ class ReservationPenaltyNotifier extends AsyncNotifier<DateTime?> {
     state = const AsyncData(null);
   }
 
-  Future<void> _delete() =>
-      ref.read(secureStorageProvider).delete(key: _storageKey);
+  Future<void> _delete() async {
+    try {
+      await ref.read(secureStorageProvider).delete(key: _storageKey);
+    } catch (error, stackTrace) {
+      AppLogger.error(
+        '패널티 만료 시각을 삭제하는 중 오류가 발생했습니다.',
+        name: 'ReservationPenaltyNotifier',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
 }
 
 final reservationPenaltyProvider =

--- a/lib/features/reservation/presentation/providers/reservation_penalty_provider.dart
+++ b/lib/features/reservation/presentation/providers/reservation_penalty_provider.dart
@@ -1,0 +1,50 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:washer/core/network/dio_client.dart';
+
+/// 예약 취소 패널티 만료시각을 로컬에 보관한다.
+///
+/// 패널티 기간에는 서버가 예약 요청을 거부하므로, 만료시각을 저장해 두고
+/// 그 사이의 예약 시도는 서버로 보내지 않고 클라이언트에서 곧바로 막는다.
+/// 앱을 재시작해도 유지되도록 secure storage에 영속화한다.
+class ReservationPenaltyNotifier extends AsyncNotifier<DateTime?> {
+  static const _storageKey = 'reservation_penalty_expires_at';
+
+  @override
+  Future<DateTime?> build() async {
+    final raw = await ref.read(secureStorageProvider).read(key: _storageKey);
+    final expiry = raw == null ? null : DateTime.tryParse(raw);
+
+    // 저장된 값이 없거나 이미 만료됐으면 정리하고 없는 상태로 시작한다.
+    if (expiry == null || !DateTime.now().isBefore(expiry)) {
+      if (raw != null) {
+        unawaited(_delete());
+      }
+      return null;
+    }
+    return expiry;
+  }
+
+  /// 서버가 알려준 패널티 만료시각을 저장한다.
+  Future<void> record(DateTime expiresAt) async {
+    await ref
+        .read(secureStorageProvider)
+        .write(key: _storageKey, value: expiresAt.toIso8601String());
+    state = AsyncData(expiresAt);
+  }
+
+  /// 만료된 패널티를 비운다.
+  Future<void> clear() async {
+    await _delete();
+    state = const AsyncData(null);
+  }
+
+  Future<void> _delete() =>
+      ref.read(secureStorageProvider).delete(key: _storageKey);
+}
+
+final reservationPenaltyProvider =
+    AsyncNotifierProvider<ReservationPenaltyNotifier, DateTime?>(
+      ReservationPenaltyNotifier.new,
+    );

--- a/test/features/reservation/reservation_test.dart
+++ b/test/features/reservation/reservation_test.dart
@@ -5,22 +5,27 @@ import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:washer/core/enums/machine_state.dart';
+import 'package:washer/core/utils/date_time_formatter.dart';
 import 'package:washer/features/reservation/data/data_sources/remote/reservation_status_remote_data_source.dart';
 import 'package:washer/features/reservation/data/models/local/active_reservation_model.dart';
 import 'package:washer/features/reservation/data/models/local/laundry_machine_model.dart';
 import 'package:washer/features/reservation/presentation/providers/reservation_status_provider.dart';
 import 'package:washer/features/reservation/data/data_sources/remote/reservation_remote_data_source.dart';
+import 'package:washer/features/reservation/data/models/remote/cancel_reservation_response.dart';
 import 'package:washer/features/reservation/data/models/remote/confirm_reservation_response.dart';
 import 'package:washer/features/reservation/presentation/providers/reservation_action_provider.dart';
+import 'package:washer/features/reservation/presentation/providers/reservation_penalty_provider.dart';
 
 class FakeReservationRemoteDataSource implements ReservationRemoteDataSource {
   FakeReservationRemoteDataSource({
     this.createdReservation = _reservedReservation,
     this.cancelError,
+    this.cancelResponse = _noPenaltyCancel,
   });
 
   final ActiveReservationModel createdReservation;
   final Object? cancelError;
+  final CancelReservationResponse cancelResponse;
   int? lastMachineId;
   String? lastStartTime;
   int? cancelledId;
@@ -36,12 +41,13 @@ class FakeReservationRemoteDataSource implements ReservationRemoteDataSource {
   }
 
   @override
-  Future<void> cancelReservation({required int id}) async {
+  Future<CancelReservationResponse> cancelReservation({required int id}) async {
     cancelledId = id;
     final nextError = cancelError;
     if (nextError != null) {
       throw nextError;
     }
+    return cancelResponse;
   }
 
   @override
@@ -53,6 +59,35 @@ class FakeReservationRemoteDataSource implements ReservationRemoteDataSource {
       code: 200,
       message: '확정되었습니다.',
     );
+  }
+}
+
+const _noPenaltyCancel = CancelReservationResponse(
+  success: true,
+  message: '예약이 취소되었습니다.',
+  penaltyApplied: false,
+  penaltyExpiresAt: '',
+);
+
+/// 예약 패널티 상태를 storage 없이 메모리로만 다루는 테스트용 notifier.
+class FakeReservationPenaltyNotifier extends ReservationPenaltyNotifier {
+  FakeReservationPenaltyNotifier([this.initialExpiry]);
+
+  final DateTime? initialExpiry;
+  DateTime? recorded;
+
+  @override
+  Future<DateTime?> build() async => initialExpiry;
+
+  @override
+  Future<void> record(DateTime expiresAt) async {
+    recorded = expiresAt;
+    state = AsyncData(expiresAt);
+  }
+
+  @override
+  Future<void> clear() async {
+    state = const AsyncData(null);
   }
 }
 
@@ -330,6 +365,9 @@ void main() {
           reservationRemoteDataSourceProvider.overrideWith(
             (ref) => reservationDataSource,
           ),
+          reservationPenaltyProvider.overrideWith(
+            FakeReservationPenaltyNotifier.new,
+          ),
           homeRemoteDataSourceProvider.overrideWith(
             (ref) => FakeHomeRemoteDataSource(
               machineStatusLoader: () async =>
@@ -361,6 +399,9 @@ void main() {
         overrides: [
           reservationRemoteDataSourceProvider.overrideWith(
             (ref) => reservationDataSource,
+          ),
+          reservationPenaltyProvider.overrideWith(
+            FakeReservationPenaltyNotifier.new,
           ),
           homeRemoteDataSourceProvider.overrideWith(
             (ref) => FakeHomeRemoteDataSource(
@@ -411,6 +452,9 @@ void main() {
           reservationRemoteDataSourceProvider.overrideWith(
             (ref) => reservationDataSource,
           ),
+          reservationPenaltyProvider.overrideWith(
+            FakeReservationPenaltyNotifier.new,
+          ),
           homeRemoteDataSourceProvider.overrideWith(
             (ref) => FakeHomeRemoteDataSource(
               machineStatusLoader: () async =>
@@ -433,6 +477,78 @@ void main() {
           fallback: '예약 취소에 실패했습니다.',
         ),
         '예약 취소 시간이 지났습니다.',
+      );
+    });
+
+    test('취소 패널티 기간이면 요청을 보내지 않고 예외를 담는다', () async {
+      final reservationDataSource = FakeReservationRemoteDataSource();
+      final expiry = DateTime.now().add(const Duration(minutes: 5));
+      final container = ProviderContainer(
+        overrides: [
+          reservationRemoteDataSourceProvider.overrideWith(
+            (ref) => reservationDataSource,
+          ),
+          reservationPenaltyProvider.overrideWith(
+            () => FakeReservationPenaltyNotifier(expiry),
+          ),
+          homeRemoteDataSourceProvider.overrideWith(
+            (ref) => FakeHomeRemoteDataSource(
+              machineStatusLoader: () async =>
+                  const MachineStatusResponse(machines: [], totalCount: 0),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container
+          .read(reservationActionProvider.notifier)
+          .reserve(machineId: 83);
+
+      expect(result, isNull);
+      // 서버 조회(GET)·예약(POST) 요청이 나가지 않아야 한다.
+      expect(reservationDataSource.lastMachineId, isNull);
+      expect(
+        container.read(reservationActionProvider).error,
+        isA<ReservationPenaltyException>(),
+      );
+    });
+
+    test('취소 시 패널티가 부과되면 만료시각을 로컬에 기록한다', () async {
+      final reservationDataSource = FakeReservationRemoteDataSource(
+        cancelResponse: const CancelReservationResponse(
+          success: true,
+          message: '취소되었으나 패널티가 부과되었습니다.',
+          penaltyApplied: true,
+          penaltyExpiresAt: '2999-01-01T00:00:00',
+        ),
+      );
+      final container = ProviderContainer(
+        overrides: [
+          reservationRemoteDataSourceProvider.overrideWith(
+            (ref) => reservationDataSource,
+          ),
+          reservationPenaltyProvider.overrideWith(
+            FakeReservationPenaltyNotifier.new,
+          ),
+          homeRemoteDataSourceProvider.overrideWith(
+            (ref) => FakeHomeRemoteDataSource(
+              machineStatusLoader: () async =>
+                  const MachineStatusResponse(machines: [], totalCount: 0),
+            ),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final result = await container
+          .read(reservationActionProvider.notifier)
+          .cancel(reservationId: 114);
+
+      expect(result, isTrue);
+      expect(
+        container.read(reservationPenaltyProvider).value,
+        DateTimeFormatter.parseServerDateTime('2999-01-01T00:00:00'),
       );
     });
   });


### PR DESCRIPTION
## 개요
Closes #230

예약 취소 시 서버가 내려주는 패널티 만료시각을 클라이언트에 저장해두고, 패널티 기간 중 예약 시도를 **서버 요청 없이 클라이언트에서 차단**합니다.

## 문제
`cancelReservation`이 `Future<void>`라 응답의 `penaltyApplied` / `penaltyExpiresAt`를 통째로 버리고 있었습니다. 그래서 패널티 기간에도 예약 시도가 `GET /machines` + `POST /reservations` 2요청을 보내고 서버에서 거부당했습니다.

## 변경
- `cancelReservation` 반환형 `void` → `CancelReservationResponse` (형제 엔드포인트 `confirm`과 동일한 파싱 방식)
- `reservationPenaltyProvider` 신규 — 만료시각을 secure storage에 영속화(기존 provider 재사용, 새 의존성 없음), 앱 재시작 후 유지, 만료 시 자동 정리
- 예약 시도 시 만료 전이면 `ReservationPenaltyException`으로 즉시 차단 + 남은 시간 안내 메시지
- **race 수정**: `record` 전 provider `build()` 완료를 기다리지 않으면 저장값이 build 결과로 덮여, 취소 직후 같은 세션에서 패널티가 안 걸리던 문제

## 효과
패널티 중 예약 시도 1회당 `GET + POST` 2건 → **0건**

## 검토했지만 유지한 것
- 예약 전 `getMachineStatus()` 사전 조회: 다른 사용자가 방금 채간 기기인지 막는 레이스 가드라 클라 캐시로 대체 불가(대체 시 서버 거부 유발) → 유지

## 테스트
- 패널티 기간 차단 / 취소 시 만료시각 기록 테스트 2건 추가
- `flutter test test/features/reservation` 15건 통과, `flutter analyze` 클린

🤖 Generated with [Claude Code](https://claude.com/claude-code)