### PR TITLE
🔀 :: (#237) - 예약 취소 응답 null 처리 및 에러 스낵바 적용

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -1,4 +1,4 @@
-API_BASE_URL=https://your-development-api.example.com/api/v2
-REFRESH_TOKEN_ENDPOINT=/auth/refresh
+API_BASE_URL=https://your-development-api.example.com/api/v2/
+REFRESH_TOKEN_ENDPOINT=auth/refresh
 OAUTH_BASE_URL=https://oauth.example.com/v1/oauth/authorize
 OAUTH_CLIENT_ID=your-development-oauth-client-id

--- a/.env.production.example
+++ b/.env.production.example
@@ -1,4 +1,4 @@
-API_BASE_URL=https://your-production-api.example.com/api/v2
-REFRESH_TOKEN_ENDPOINT=/auth/refresh
+API_BASE_URL=https://your-production-api.example.com/api/v2/
+REFRESH_TOKEN_ENDPOINT=auth/refresh
 OAUTH_BASE_URL=https://oauth.example.com/v1/oauth/authorize
 OAUTH_CLIENT_ID=your-production-oauth-client-id

--- a/lib/core/env/app_environment.dart
+++ b/lib/core/env/app_environment.dart
@@ -34,7 +34,7 @@ class AppEnvironment {
       flavor: flavor,
       apiBaseUrl: _resolveUrl('API_BASE_URL', flavor),
       refreshTokenEndpoint:
-          dotenv.env['REFRESH_TOKEN_ENDPOINT'] ?? '/auth/refresh',
+          dotenv.env['REFRESH_TOKEN_ENDPOINT'] ?? 'auth/refresh',
       oauthBaseUrl: _resolveOptionalUrl('OAUTH_BASE_URL', flavor),
       oauthClientId: dotenv.env['OAUTH_CLIENT_ID'] ?? '',
       allowBadCertificates: _resolveAllowBadCertificates(flavor),

--- a/lib/core/errors/app_exception.dart
+++ b/lib/core/errors/app_exception.dart
@@ -1,0 +1,100 @@
+﻿import 'package:dio/dio.dart';
+
+class AppException {
+  AppException({
+    required this.message,
+    this.statusCode,
+    this.debugMessage,
+  });
+
+  final String message;
+  final int? statusCode;
+  final String? debugMessage;
+
+  factory AppException.from(Object? error) {
+    if (error is DioException) {
+      return AppException._fromDioException(error);
+    }
+
+    if (error is FormatException) {
+      return AppException(
+        message: '데이터를 불러오는 중 오류가 발생했습니다.',
+        debugMessage: error.message,
+      );
+    }
+
+    if (error is TypeError) {
+      return AppException(
+        message: '데이터를 불러오는 중 오류가 발생했습니다.',
+        debugMessage: error.toString(),
+      );
+    }
+
+    return AppException(
+      message: '알 수 없는 오류가 발생했습니다.',
+      debugMessage: error?.toString(),
+    );
+  }
+
+  factory AppException._fromDioException(DioException exception) {
+    final statusCode = exception.response?.statusCode;
+    final type = exception.type;
+
+    if (statusCode == null || type == DioExceptionType.connectionError) {
+      return AppException(
+        message: '네트워크 연결을 확인해주세요.',
+        statusCode: statusCode,
+        debugMessage: exception.message,
+      );
+    }
+
+    if (statusCode == 400) {
+      return AppException(
+        message: '요청 정보가 올바르지 않습니다.',
+        statusCode: statusCode,
+        debugMessage: exception.message,
+      );
+    }
+
+    if (statusCode == 401) {
+      return AppException(
+        message: '로그인이 만료되었습니다. 다시 로그인해주세요.',
+        statusCode: statusCode,
+        debugMessage: exception.message,
+      );
+    }
+
+    if (statusCode == 404) {
+      return AppException(
+        message: '요청한 정보를 찾을 수 없습니다.',
+        statusCode: statusCode,
+        debugMessage: exception.message,
+      );
+    }
+
+    if (statusCode >= 500) {
+      return AppException(
+        message: '서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+        statusCode: statusCode,
+        debugMessage: exception.message,
+      );
+    }
+
+    if (type == DioExceptionType.receiveTimeout ||
+        type == DioExceptionType.sendTimeout ||
+        type == DioExceptionType.connectionTimeout) {
+      return AppException(
+        message: '네트워크 연결을 확인해주세요.',
+        statusCode: statusCode,
+        debugMessage: exception.message,
+      );
+    }
+
+    // Fallback: unknown HTTP client error
+    return AppException(
+      message: '알 수 없는 오류가 발생했습니다.',
+      statusCode: statusCode,
+      debugMessage: exception.message,
+    );
+  }
+}

--- a/lib/core/network/auth_interceptor.dart
+++ b/lib/core/network/auth_interceptor.dart
@@ -154,7 +154,7 @@ class AuthInterceptor extends Interceptor {
   }
 
   bool _shouldSkipAuth(String path) {
-    return path.contains('/auth/');
+    return path.startsWith('auth/') || path.startsWith('/auth/');
   }
 
   Future<String?> _refreshToken() async {

--- a/lib/core/widgets/error_snack_bar.dart
+++ b/lib/core/widgets/error_snack_bar.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:washer/core/errors/app_exception.dart';
+
+extension ErrorSnackBarExtension on BuildContext {
+  void showErrorSnackBar(Object? error) {
+    final appException = AppException.from(error);
+    final messenger = ScaffoldMessenger.of(this);
+    messenger.hideCurrentSnackBar();
+    messenger.showSnackBar(
+      SnackBar(
+        content: Text(appException.message),
+        behavior: SnackBarBehavior.floating,
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/error_snack_bar.dart
+++ b/lib/core/widgets/error_snack_bar.dart
@@ -3,10 +3,15 @@ import 'package:washer/core/errors/app_exception.dart';
 
 extension ErrorSnackBarExtension on BuildContext {
   void showErrorSnackBar(Object? error) {
+    ScaffoldMessenger.of(this).showErrorSnackBar(error);
+  }
+}
+
+extension ErrorSnackBarMessengerExtension on ScaffoldMessengerState {
+  void showErrorSnackBar(Object? error) {
     final appException = AppException.from(error);
-    final messenger = ScaffoldMessenger.of(this);
-    messenger.hideCurrentSnackBar();
-    messenger.showSnackBar(
+    hideCurrentSnackBar();
+    showSnackBar(
       SnackBar(
         content: Text(appException.message),
         behavior: SnackBarBehavior.floating,

--- a/lib/features/alarm/data/data_sources/alarm_data_source.dart
+++ b/lib/features/alarm/data/data_sources/alarm_data_source.dart
@@ -18,16 +18,16 @@ abstract class AlarmDataSource {
 abstract class AlarmApiService {
   factory AlarmApiService(Dio dio, {String baseUrl}) = _AlarmApiService;
 
-  @GET('/notifications')
+  @GET('notifications')
   Future<HttpResponse<dynamic>> getAlarmList();
 
-  @DELETE('/notifications')
+  @DELETE('notifications')
   Future<void> deleteAllNotifications();
 
-  @POST('/notifications/fcm-token')
+  @POST('notifications/fcm-token')
   Future<void> registerFcmToken(@Body() Map<String, dynamic> payload);
 
-  @DELETE('/notifications/fcm-token')
+  @DELETE('notifications/fcm-token')
   Future<void> deleteFcmToken();
 }
 

--- a/lib/features/alarm/data/data_sources/alarm_data_source.g.dart
+++ b/lib/features/alarm/data/data_sources/alarm_data_source.g.dart
@@ -29,7 +29,7 @@ class _AlarmApiService implements AlarmApiService {
       Options(method: 'GET', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            '/notifications',
+            'notifications',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -51,7 +51,7 @@ class _AlarmApiService implements AlarmApiService {
       Options(method: 'DELETE', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            '/notifications',
+            'notifications',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -71,7 +71,7 @@ class _AlarmApiService implements AlarmApiService {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            '/notifications/fcm-token',
+            'notifications/fcm-token',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -90,7 +90,7 @@ class _AlarmApiService implements AlarmApiService {
       Options(method: 'DELETE', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            '/notifications/fcm-token',
+            'notifications/fcm-token',
             queryParameters: queryParameters,
             data: _data,
           )

--- a/lib/features/auth/data/data_sources/remote/auth_remote_data_source.dart
+++ b/lib/features/auth/data/data_sources/remote/auth_remote_data_source.dart
@@ -18,10 +18,10 @@ abstract class AuthRemoteDataSource {
 abstract class AuthApiService {
   factory AuthApiService(Dio dio, {String baseUrl}) = _AuthApiService;
 
-  @POST('/auth/login')
+  @POST('auth/login')
   Future<HttpResponse<dynamic>> login(@Body() Map<String, dynamic> payload);
 
-  @POST('/auth/refresh')
+  @POST('auth/refresh')
   Future<HttpResponse<dynamic>> refresh(@Body() Map<String, dynamic> payload);
 }
 

--- a/lib/features/auth/data/data_sources/remote/auth_remote_data_source.g.dart
+++ b/lib/features/auth/data/data_sources/remote/auth_remote_data_source.g.dart
@@ -30,7 +30,7 @@ class _AuthApiService implements AuthApiService {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            '/auth/login',
+            'auth/login',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -53,7 +53,7 @@ class _AuthApiService implements AuthApiService {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            '/auth/refresh',
+            'auth/refresh',
             queryParameters: queryParameters,
             data: _data,
           )

--- a/lib/features/history/data/data_sources/history_remote_data_source.dart
+++ b/lib/features/history/data/data_sources/history_remote_data_source.dart
@@ -21,7 +21,7 @@ abstract class HistoryRemoteDataSource {
 abstract class HistoryApiService {
   factory HistoryApiService(Dio dio, {String baseUrl}) = _HistoryApiService;
 
-  @GET('/machines/{machineId}/history')
+  @GET('machines/{machineId}/history')
   Future<HttpResponse<dynamic>> getMachineHistory({
     @Path('machineId') required int machineId,
     @Query('startDate') required String startDate,

--- a/lib/features/history/data/data_sources/history_remote_data_source.g.dart
+++ b/lib/features/history/data/data_sources/history_remote_data_source.g.dart
@@ -40,7 +40,7 @@ class _HistoryApiService implements HistoryApiService {
       Options(method: 'GET', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            '/machines/${machineId}/history',
+            'machines/${machineId}/history',
             queryParameters: queryParameters,
             data: _data,
           )

--- a/lib/features/history/presentation/providers/history_provider.dart
+++ b/lib/features/history/presentation/providers/history_provider.dart
@@ -1,7 +1,10 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 import 'package:washer/core/utils/app_logger.dart';
 import 'package:washer/features/history/data/data_sources/history_remote_data_source.dart';
 import 'package:washer/features/history/presentation/states/history_state.dart';
+
+final historyErrorProvider = StateProvider<Object?>((ref) => null);
 
 class HistoryNotifier extends Notifier<HistoryState> {
   @override
@@ -9,6 +12,7 @@ class HistoryNotifier extends Notifier<HistoryState> {
 
   Future<void> fetchTodayHistory(int machineId) async {
     state = state.copyWith(isLoading: true, errorMessage: null);
+    ref.read(historyErrorProvider.notifier).state = null;
 
     try {
       final now = DateTime.now();
@@ -50,6 +54,7 @@ class HistoryNotifier extends Notifier<HistoryState> {
         error: error,
         stackTrace: stackTrace,
       );
+      ref.read(historyErrorProvider.notifier).state = error;
       state = state.copyWith(
         errorMessage: '사용 기록을 불러오는데 실패했습니다.',
         isLoading: false,

--- a/lib/features/history/presentation/widgets/history_dialog.dart
+++ b/lib/features/history/presentation/widgets/history_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:washer/core/widgets/error_snack_bar.dart';
 import 'package:washer/shared/theme/color.dart';
 import 'package:washer/shared/theme/spacing.dart';
 import 'package:washer/shared/theme/typography.dart';
@@ -37,6 +38,12 @@ class _HistoryDialogState extends ConsumerState<HistoryDialog> {
 
   @override
   Widget build(BuildContext context) {
+    ref.listen<Object?>(historyErrorProvider, (previous, next) {
+      if (next != null) {
+        context.showErrorSnackBar(next);
+      }
+    });
+
     final state = ref.watch(historyProvider);
 
     return Dialog(

--- a/lib/features/history/presentation/widgets/history_dialog.dart
+++ b/lib/features/history/presentation/widgets/history_dialog.dart
@@ -78,15 +78,7 @@ class _HistoryDialogState extends ConsumerState<HistoryDialog> {
     }
 
     if (state.errorMessage != null) {
-      return Padding(
-        padding: const EdgeInsets.all(20),
-        child: Center(
-          child: Text(
-            state.errorMessage!,
-            style: WasherTypography.body1(WasherColor.errorColor),
-          ),
-        ),
-      );
+      return const SizedBox.shrink();
     }
 
     if (state.historyList.isEmpty) {

--- a/lib/features/report/data/data_sources/remote/report_remote_data_source.dart
+++ b/lib/features/report/data/data_sources/remote/report_remote_data_source.dart
@@ -16,7 +16,7 @@ abstract class ReportRemoteDataSource {
 abstract class ReportApiService {
   factory ReportApiService(Dio dio, {String baseUrl}) = _ReportApiService;
 
-  @POST('/malfunction-reports')
+  @POST('malfunction-reports')
   Future<void> createMalfunctionReport(
     @Body() Map<String, dynamic> payload,
   );

--- a/lib/features/report/data/data_sources/remote/report_remote_data_source.g.dart
+++ b/lib/features/report/data/data_sources/remote/report_remote_data_source.g.dart
@@ -30,7 +30,7 @@ class _ReportApiService implements ReportApiService {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            '/malfunction-reports',
+            'malfunction-reports',
             queryParameters: queryParameters,
             data: _data,
           )

--- a/lib/features/reservation/data/data_sources/remote/reservation_remote_data_source.dart
+++ b/lib/features/reservation/data/data_sources/remote/reservation_remote_data_source.dart
@@ -29,15 +29,15 @@ abstract class ReservationApiService {
   factory ReservationApiService(Dio dio, {String baseUrl}) =
       _ReservationApiService;
 
-  @POST('/reservations')
+  @POST('reservations')
   Future<HttpResponse<dynamic>> createReservation(
     @Body() Map<String, dynamic> payload,
   );
 
-  @DELETE('/reservations/{id}')
+  @DELETE('reservations/{id}')
   Future<HttpResponse<dynamic>> cancelReservation(@Path('id') int id);
 
-  @PUT('/reservations/{id}/confirm')
+  @PUT('reservations/{id}/confirm')
   Future<HttpResponse<dynamic>> confirmReservation(@Path('id') int id);
 }
 

--- a/lib/features/reservation/data/data_sources/remote/reservation_remote_data_source.g.dart
+++ b/lib/features/reservation/data/data_sources/remote/reservation_remote_data_source.g.dart
@@ -32,7 +32,7 @@ class _ReservationApiService implements ReservationApiService {
       Options(method: 'POST', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            '/reservations',
+            'reservations',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -54,7 +54,7 @@ class _ReservationApiService implements ReservationApiService {
       Options(method: 'DELETE', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            '/reservations/${id}',
+            'reservations/${id}',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -76,7 +76,7 @@ class _ReservationApiService implements ReservationApiService {
       Options(method: 'PUT', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            '/reservations/${id}/confirm',
+            'reservations/${id}/confirm',
             queryParameters: queryParameters,
             data: _data,
           )

--- a/lib/features/reservation/data/data_sources/remote/reservation_status_remote_data_source.dart
+++ b/lib/features/reservation/data/data_sources/remote/reservation_status_remote_data_source.dart
@@ -17,10 +17,10 @@ abstract class HomeRemoteDataSource {
 abstract class HomeApiService {
   factory HomeApiService(Dio dio, {String baseUrl}) = _HomeApiService;
 
-  @GET('/machines/status')
+  @GET('machines/status')
   Future<HttpResponse<dynamic>> getMachineStatus();
 
-  @GET('/reservations/active/room')
+  @GET('reservations/active/room')
   Future<HttpResponse<dynamic>> getActiveReservations();
 }
 

--- a/lib/features/reservation/data/data_sources/remote/reservation_status_remote_data_source.g.dart
+++ b/lib/features/reservation/data/data_sources/remote/reservation_status_remote_data_source.g.dart
@@ -29,7 +29,7 @@ class _HomeApiService implements HomeApiService {
       Options(method: 'GET', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            '/machines/status',
+            'machines/status',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -51,7 +51,7 @@ class _HomeApiService implements HomeApiService {
       Options(method: 'GET', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            '/reservations/active/room',
+            'reservations/active/room',
             queryParameters: queryParameters,
             data: _data,
           )

--- a/lib/features/reservation/data/data_sources/remote/smartthings_status_remote_data_source.dart
+++ b/lib/features/reservation/data/data_sources/remote/smartthings_status_remote_data_source.dart
@@ -21,7 +21,7 @@ abstract class SmartThingsStatusApiService {
   factory SmartThingsStatusApiService(Dio dio, {String baseUrl}) =
       _SmartThingsStatusApiService;
 
-  @GET('/devices/{deviceId}/status')
+  @GET('devices/{deviceId}/status')
   Future<HttpResponse<dynamic>> getDeviceStatus(
     @Path('deviceId') String deviceId,
     @Header('Authorization') String authorization,

--- a/lib/features/reservation/data/data_sources/remote/smartthings_status_remote_data_source.g.dart
+++ b/lib/features/reservation/data/data_sources/remote/smartthings_status_remote_data_source.g.dart
@@ -33,7 +33,7 @@ class _SmartThingsStatusApiService implements SmartThingsStatusApiService {
       Options(method: 'GET', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            '/devices/${deviceId}/status',
+            'devices/${deviceId}/status',
             queryParameters: queryParameters,
             data: _data,
           )

--- a/lib/features/reservation/data/data_sources/remote/smartthings_token_remote_data_source.dart
+++ b/lib/features/reservation/data/data_sources/remote/smartthings_token_remote_data_source.dart
@@ -16,7 +16,7 @@ abstract class SmartThingsTokenApiService {
   factory SmartThingsTokenApiService(Dio dio, {String baseUrl}) =
       _SmartThingsTokenApiService;
 
-  @GET('/smartthings/token')
+  @GET('smartthings/token')
   Future<HttpResponse<dynamic>> getToken();
 }
 

--- a/lib/features/reservation/data/data_sources/remote/smartthings_token_remote_data_source.g.dart
+++ b/lib/features/reservation/data/data_sources/remote/smartthings_token_remote_data_source.g.dart
@@ -29,7 +29,7 @@ class _SmartThingsTokenApiService implements SmartThingsTokenApiService {
       Options(method: 'GET', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            '/smartthings/token',
+            'smartthings/token',
             queryParameters: queryParameters,
             data: _data,
           )

--- a/lib/features/reservation/data/models/remote/cancel_reservation_response.dart
+++ b/lib/features/reservation/data/models/remote/cancel_reservation_response.dart
@@ -6,10 +6,10 @@ part 'cancel_reservation_response.g.dart';
 @freezed
 abstract class CancelReservationResponse with _$CancelReservationResponse {
   const factory CancelReservationResponse({
-    required bool success,
-    required String message,
-    required bool penaltyApplied,
-    required String penaltyExpiresAt,
+    @JsonKey(defaultValue: false) required bool success,
+    @JsonKey(defaultValue: '') required String message,
+    @JsonKey(defaultValue: false) required bool penaltyApplied,
+    @JsonKey(defaultValue: '') required String penaltyExpiresAt,
   }) = _CancelReservationResponse;
 
   factory CancelReservationResponse.fromJson(Map<String, dynamic> json) =>

--- a/lib/features/reservation/data/models/remote/cancel_reservation_response.dart
+++ b/lib/features/reservation/data/models/remote/cancel_reservation_response.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: invalid_annotation_target
+
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'cancel_reservation_response.freezed.dart';

--- a/lib/features/reservation/data/models/remote/cancel_reservation_response.freezed.dart
+++ b/lib/features/reservation/data/models/remote/cancel_reservation_response.freezed.dart
@@ -15,7 +15,7 @@ T _$identity<T>(T value) => value;
 /// @nodoc
 mixin _$CancelReservationResponse {
 
- bool get success; String get message; bool get penaltyApplied; String get penaltyExpiresAt;
+@JsonKey(defaultValue: false) bool get success;@JsonKey(defaultValue: '') String get message;@JsonKey(defaultValue: false) bool get penaltyApplied;@JsonKey(defaultValue: '') String get penaltyExpiresAt;
 /// Create a copy of CancelReservationResponse
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -48,7 +48,7 @@ abstract mixin class $CancelReservationResponseCopyWith<$Res>  {
   factory $CancelReservationResponseCopyWith(CancelReservationResponse value, $Res Function(CancelReservationResponse) _then) = _$CancelReservationResponseCopyWithImpl;
 @useResult
 $Res call({
- bool success, String message, bool penaltyApplied, String penaltyExpiresAt
+@JsonKey(defaultValue: false) bool success,@JsonKey(defaultValue: '') String message,@JsonKey(defaultValue: false) bool penaltyApplied,@JsonKey(defaultValue: '') String penaltyExpiresAt
 });
 
 
@@ -156,7 +156,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool success,  String message,  bool penaltyApplied,  String penaltyExpiresAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function(@JsonKey(defaultValue: false)  bool success, @JsonKey(defaultValue: '')  String message, @JsonKey(defaultValue: false)  bool penaltyApplied, @JsonKey(defaultValue: '')  String penaltyExpiresAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _CancelReservationResponse() when $default != null:
 return $default(_that.success,_that.message,_that.penaltyApplied,_that.penaltyExpiresAt);case _:
@@ -177,7 +177,7 @@ return $default(_that.success,_that.message,_that.penaltyApplied,_that.penaltyEx
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool success,  String message,  bool penaltyApplied,  String penaltyExpiresAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function(@JsonKey(defaultValue: false)  bool success, @JsonKey(defaultValue: '')  String message, @JsonKey(defaultValue: false)  bool penaltyApplied, @JsonKey(defaultValue: '')  String penaltyExpiresAt)  $default,) {final _that = this;
 switch (_that) {
 case _CancelReservationResponse():
 return $default(_that.success,_that.message,_that.penaltyApplied,_that.penaltyExpiresAt);case _:
@@ -197,7 +197,7 @@ return $default(_that.success,_that.message,_that.penaltyApplied,_that.penaltyEx
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool success,  String message,  bool penaltyApplied,  String penaltyExpiresAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function(@JsonKey(defaultValue: false)  bool success, @JsonKey(defaultValue: '')  String message, @JsonKey(defaultValue: false)  bool penaltyApplied, @JsonKey(defaultValue: '')  String penaltyExpiresAt)?  $default,) {final _that = this;
 switch (_that) {
 case _CancelReservationResponse() when $default != null:
 return $default(_that.success,_that.message,_that.penaltyApplied,_that.penaltyExpiresAt);case _:
@@ -212,13 +212,13 @@ return $default(_that.success,_that.message,_that.penaltyApplied,_that.penaltyEx
 @JsonSerializable()
 
 class _CancelReservationResponse implements CancelReservationResponse {
-  const _CancelReservationResponse({required this.success, required this.message, required this.penaltyApplied, required this.penaltyExpiresAt});
+  const _CancelReservationResponse({@JsonKey(defaultValue: false) required this.success, @JsonKey(defaultValue: '') required this.message, @JsonKey(defaultValue: false) required this.penaltyApplied, @JsonKey(defaultValue: '') required this.penaltyExpiresAt});
   factory _CancelReservationResponse.fromJson(Map<String, dynamic> json) => _$CancelReservationResponseFromJson(json);
 
-@override final  bool success;
-@override final  String message;
-@override final  bool penaltyApplied;
-@override final  String penaltyExpiresAt;
+@override@JsonKey(defaultValue: false) final  bool success;
+@override@JsonKey(defaultValue: '') final  String message;
+@override@JsonKey(defaultValue: false) final  bool penaltyApplied;
+@override@JsonKey(defaultValue: '') final  String penaltyExpiresAt;
 
 /// Create a copy of CancelReservationResponse
 /// with the given fields replaced by the non-null parameter values.
@@ -253,7 +253,7 @@ abstract mixin class _$CancelReservationResponseCopyWith<$Res> implements $Cance
   factory _$CancelReservationResponseCopyWith(_CancelReservationResponse value, $Res Function(_CancelReservationResponse) _then) = __$CancelReservationResponseCopyWithImpl;
 @override @useResult
 $Res call({
- bool success, String message, bool penaltyApplied, String penaltyExpiresAt
+@JsonKey(defaultValue: false) bool success,@JsonKey(defaultValue: '') String message,@JsonKey(defaultValue: false) bool penaltyApplied,@JsonKey(defaultValue: '') String penaltyExpiresAt
 });
 
 

--- a/lib/features/reservation/data/models/remote/cancel_reservation_response.g.dart
+++ b/lib/features/reservation/data/models/remote/cancel_reservation_response.g.dart
@@ -9,10 +9,10 @@ part of 'cancel_reservation_response.dart';
 _CancelReservationResponse _$CancelReservationResponseFromJson(
   Map<String, dynamic> json,
 ) => _CancelReservationResponse(
-  success: json['success'] as bool,
-  message: json['message'] as String,
-  penaltyApplied: json['penaltyApplied'] as bool,
-  penaltyExpiresAt: json['penaltyExpiresAt'] as String,
+  success: json['success'] as bool? ?? false,
+  message: json['message'] as String? ?? '',
+  penaltyApplied: json['penaltyApplied'] as bool? ?? false,
+  penaltyExpiresAt: json['penaltyExpiresAt'] as String? ?? '',
 );
 
 Map<String, dynamic> _$CancelReservationResponseToJson(

--- a/lib/features/user/data/data_sources/remote/user_remote_data_source.dart
+++ b/lib/features/user/data/data_sources/remote/user_remote_data_source.dart
@@ -16,10 +16,10 @@ abstract class UserRemoteDataSource {
 abstract class UserApiService {
   factory UserApiService(Dio dio, {String baseUrl}) = _UserApiService;
 
-  @GET('/users/my')
+  @GET('users/my')
   Future<HttpResponse<dynamic>> getMyUser();
 
-  @DELETE('/users/me')
+  @DELETE('users/me')
   Future<HttpResponse<dynamic>> withdraw();
 }
 

--- a/lib/features/user/data/data_sources/remote/user_remote_data_source.g.dart
+++ b/lib/features/user/data/data_sources/remote/user_remote_data_source.g.dart
@@ -29,7 +29,7 @@ class _UserApiService implements UserApiService {
       Options(method: 'GET', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            '/users/my',
+            'users/my',
             queryParameters: queryParameters,
             data: _data,
           )
@@ -51,7 +51,7 @@ class _UserApiService implements UserApiService {
       Options(method: 'DELETE', headers: _headers, extra: _extra)
           .compose(
             _dio.options,
-            '/users/me',
+            'users/me',
             queryParameters: queryParameters,
             data: _data,
           )

--- a/lib/shared/ui/dialog/dialog_action.dart
+++ b/lib/shared/ui/dialog/dialog_action.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:washer/core/widgets/error_snack_bar.dart';
 import 'package:washer/shared/ui/loading_overlay.dart';
 import 'package:washer/core/utils/app_logger.dart';
 
@@ -19,6 +20,7 @@ class DialogAction<R> {
     required this.successMessage,
     required this.failureMessage,
     required this.logName,
+    this.failureError,
     this.showLoading = false,
   });
 
@@ -27,6 +29,7 @@ class DialogAction<R> {
   final String successMessage;
   final String Function(ProviderContainer container) failureMessage;
   final String logName;
+  final Object? Function(ProviderContainer container)? failureError;
 
   /// 작업 동안 루트 오버레이에 로딩 인디케이터를 표시할지 여부.
   final bool showLoading;
@@ -70,9 +73,14 @@ Future<void> runDialogAction<R>(
         messenger.showSnackBar(SnackBar(content: Text(action.successMessage)));
       }
     } else if (messenger.mounted) {
-      messenger.showSnackBar(
-        SnackBar(content: Text(action.failureMessage(container))),
-      );
+      final failureError = action.failureError?.call(container);
+      if (failureError != null) {
+        messenger.showErrorSnackBar(failureError);
+      } else {
+        messenger.showSnackBar(
+          SnackBar(content: Text(action.failureMessage(container))),
+        );
+      }
     }
   } catch (error, stackTrace) {
     AppLogger.error(
@@ -82,7 +90,7 @@ Future<void> runDialogAction<R>(
       stackTrace: stackTrace,
     );
     if (messenger.mounted) {
-      messenger.showSnackBar(SnackBar(content: Text('오류: $error')));
+      messenger.showErrorSnackBar(error);
     }
   }
 }

--- a/lib/shared/ui/dialog/dialog_actions.dart
+++ b/lib/shared/ui/dialog/dialog_actions.dart
@@ -15,12 +15,14 @@ abstract final class DialogActions {
     required int machineId,
   }) {
     return DialogAction<ActiveReservationModel?>(
-      run: (container) =>
-          container.read(reservationActionProvider.notifier).reserve(
+      run: (container) => container
+          .read(reservationActionProvider.notifier)
+          .reserve(
             machineId: machineId,
           ),
       isSuccess: (reservation) => reservation != null,
-      successMessage: '$machineName 예약이 완료되었습니다\n'
+      successMessage:
+          '$machineName 예약이 완료되었습니다\n'
           '$reservationExpiryMinutes분 동안 기기 연결을 확인합니다',
       failureMessage: (container) => reserveFailureMessage(
         container.read(reservationActionProvider).error,
@@ -33,8 +35,9 @@ abstract final class DialogActions {
   /// 예약 취소.
   static DialogAction<bool> cancelReservation({required int reservationId}) {
     return DialogAction<bool>(
-      run: (container) =>
-          container.read(reservationActionProvider.notifier).cancel(
+      run: (container) => container
+          .read(reservationActionProvider.notifier)
+          .cancel(
             reservationId: reservationId,
           ),
       isSuccess: (didCancel) => didCancel,
@@ -43,6 +46,8 @@ abstract final class DialogActions {
         container.read(reservationActionProvider).error,
         fallback: '예약 취소에 실패했습니다.',
       ),
+      failureError: (container) =>
+          container.read(reservationActionProvider).error,
       logName: 'CancelReservationAction',
     );
   }
@@ -53,8 +58,9 @@ abstract final class DialogActions {
     required String description,
   }) {
     return DialogAction<bool>(
-      run: (container) =>
-          container.read(reportProvider.notifier).createMalfunctionReport(
+      run: (container) => container
+          .read(reportProvider.notifier)
+          .createMalfunctionReport(
             machineId: machineId,
             description: description,
           ),


### PR DESCRIPTION
## 💡 개요

예약 취소 응답에서 null 값이 내려올 때 발생하는 파싱 오류를 수정하고,  
예약 취소 및 사용 내역 조회 실패 상황에서 사용자에게 에러 스낵바를 표시하도록 수정했습니다.

## 🔗 관련 이슈

Close #237

## 📃 작업내용

- `CancelReservationResponse`에서 null 응답으로 인한 파싱 오류를 방지하도록 수정했습니다.
- 공통 에러 스낵바 위젯을 추가했습니다.
- 사용 내역 조회 실패 시 에러 스낵바가 표시되도록 적용했습니다.
- 예약 취소 실패 시 에러 스낵바가 표시되도록 적용했습니다.
- 사용 기록이 0건인 경우는 에러가 아니므로 기존 empty UI를 유지했습니다.

## 🔍 테스트 방법
- 아직 에뮬로 테스트를 못해봣습니다 

## 🖼️ 스크린샷

없음

## 🙋‍♂️ 질문사항

- 공통 에러 스낵바 적용 방식이 적절한지 확인 부탁드립니다.
- 기존 empty UI와 에러 스낵바 처리 기준이 괜찮은지 확인 부탁드립니다.
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.

## ✅ 체크리스트

- [ ] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [ ] 불필요한 코드가 없는지 확인했습니다.
- [ ] 코드 스타일 가이드를 준수했습니다.
- [ ] 기존 기능이 정상적으로 작동하는지 확인했습니다.