### PR TITLE
🔀 :: (#239) - 사용 기록 조회 시 completionTime null 파싱 오류 수정

### DIFF
--- a/lib/features/history/data/models/machine_history_response.dart
+++ b/lib/features/history/data/models/machine_history_response.dart
@@ -24,7 +24,7 @@ abstract class HistoryContent with _$HistoryContent {
     required int id,
     required String userRoomNumber,
     required String startTime,
-    required String completionTime,
+    String? completionTime,
     required String status,
     required String createdAt,
   }) = _HistoryContent;

--- a/lib/features/history/data/models/machine_history_response.freezed.dart
+++ b/lib/features/history/data/models/machine_history_response.freezed.dart
@@ -299,7 +299,7 @@ as bool,
 /// @nodoc
 mixin _$HistoryContent {
 
- int get id; String get userRoomNumber; String get startTime; String get completionTime; String get status; String get createdAt;
+ int get id; String get userRoomNumber; String get startTime; String? get completionTime; String get status; String get createdAt;
 /// Create a copy of HistoryContent
 /// with the given fields replaced by the non-null parameter values.
 @JsonKey(includeFromJson: false, includeToJson: false)
@@ -332,7 +332,7 @@ abstract mixin class $HistoryContentCopyWith<$Res>  {
   factory $HistoryContentCopyWith(HistoryContent value, $Res Function(HistoryContent) _then) = _$HistoryContentCopyWithImpl;
 @useResult
 $Res call({
- int id, String userRoomNumber, String startTime, String completionTime, String status, String createdAt
+ int id, String userRoomNumber, String startTime, String? completionTime, String status, String createdAt
 });
 
 
@@ -349,13 +349,13 @@ class _$HistoryContentCopyWithImpl<$Res>
 
 /// Create a copy of HistoryContent
 /// with the given fields replaced by the non-null parameter values.
-@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? userRoomNumber = null,Object? startTime = null,Object? completionTime = null,Object? status = null,Object? createdAt = null,}) {
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? userRoomNumber = null,Object? startTime = null,Object? completionTime = freezed,Object? status = null,Object? createdAt = null,}) {
   return _then(_self.copyWith(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as int,userRoomNumber: null == userRoomNumber ? _self.userRoomNumber : userRoomNumber // ignore: cast_nullable_to_non_nullable
 as String,startTime: null == startTime ? _self.startTime : startTime // ignore: cast_nullable_to_non_nullable
-as String,completionTime: null == completionTime ? _self.completionTime : completionTime // ignore: cast_nullable_to_non_nullable
-as String,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as String,completionTime: freezed == completionTime ? _self.completionTime : completionTime // ignore: cast_nullable_to_non_nullable
+as String?,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
 as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
 as String,
   ));
@@ -442,7 +442,7 @@ return $default(_that);case _:
 /// }
 /// ```
 
-@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String userRoomNumber,  String startTime,  String completionTime,  String status,  String createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( int id,  String userRoomNumber,  String startTime,  String? completionTime,  String status,  String createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
 switch (_that) {
 case _HistoryContent() when $default != null:
 return $default(_that.id,_that.userRoomNumber,_that.startTime,_that.completionTime,_that.status,_that.createdAt);case _:
@@ -463,7 +463,7 @@ return $default(_that.id,_that.userRoomNumber,_that.startTime,_that.completionTi
 /// }
 /// ```
 
-@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String userRoomNumber,  String startTime,  String completionTime,  String status,  String createdAt)  $default,) {final _that = this;
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( int id,  String userRoomNumber,  String startTime,  String? completionTime,  String status,  String createdAt)  $default,) {final _that = this;
 switch (_that) {
 case _HistoryContent():
 return $default(_that.id,_that.userRoomNumber,_that.startTime,_that.completionTime,_that.status,_that.createdAt);case _:
@@ -483,7 +483,7 @@ return $default(_that.id,_that.userRoomNumber,_that.startTime,_that.completionTi
 /// }
 /// ```
 
-@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String userRoomNumber,  String startTime,  String completionTime,  String status,  String createdAt)?  $default,) {final _that = this;
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( int id,  String userRoomNumber,  String startTime,  String? completionTime,  String status,  String createdAt)?  $default,) {final _that = this;
 switch (_that) {
 case _HistoryContent() when $default != null:
 return $default(_that.id,_that.userRoomNumber,_that.startTime,_that.completionTime,_that.status,_that.createdAt);case _:
@@ -498,13 +498,13 @@ return $default(_that.id,_that.userRoomNumber,_that.startTime,_that.completionTi
 @JsonSerializable()
 
 class _HistoryContent implements HistoryContent {
-  const _HistoryContent({required this.id, required this.userRoomNumber, required this.startTime, required this.completionTime, required this.status, required this.createdAt});
+  const _HistoryContent({required this.id, required this.userRoomNumber, required this.startTime, this.completionTime, required this.status, required this.createdAt});
   factory _HistoryContent.fromJson(Map<String, dynamic> json) => _$HistoryContentFromJson(json);
 
 @override final  int id;
 @override final  String userRoomNumber;
 @override final  String startTime;
-@override final  String completionTime;
+@override final  String? completionTime;
 @override final  String status;
 @override final  String createdAt;
 
@@ -541,7 +541,7 @@ abstract mixin class _$HistoryContentCopyWith<$Res> implements $HistoryContentCo
   factory _$HistoryContentCopyWith(_HistoryContent value, $Res Function(_HistoryContent) _then) = __$HistoryContentCopyWithImpl;
 @override @useResult
 $Res call({
- int id, String userRoomNumber, String startTime, String completionTime, String status, String createdAt
+ int id, String userRoomNumber, String startTime, String? completionTime, String status, String createdAt
 });
 
 
@@ -558,13 +558,13 @@ class __$HistoryContentCopyWithImpl<$Res>
 
 /// Create a copy of HistoryContent
 /// with the given fields replaced by the non-null parameter values.
-@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? userRoomNumber = null,Object? startTime = null,Object? completionTime = null,Object? status = null,Object? createdAt = null,}) {
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? userRoomNumber = null,Object? startTime = null,Object? completionTime = freezed,Object? status = null,Object? createdAt = null,}) {
   return _then(_HistoryContent(
 id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
 as int,userRoomNumber: null == userRoomNumber ? _self.userRoomNumber : userRoomNumber // ignore: cast_nullable_to_non_nullable
 as String,startTime: null == startTime ? _self.startTime : startTime // ignore: cast_nullable_to_non_nullable
-as String,completionTime: null == completionTime ? _self.completionTime : completionTime // ignore: cast_nullable_to_non_nullable
-as String,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
+as String,completionTime: freezed == completionTime ? _self.completionTime : completionTime // ignore: cast_nullable_to_non_nullable
+as String?,status: null == status ? _self.status : status // ignore: cast_nullable_to_non_nullable
 as String,createdAt: null == createdAt ? _self.createdAt : createdAt // ignore: cast_nullable_to_non_nullable
 as String,
   ));

--- a/lib/features/history/data/models/machine_history_response.g.dart
+++ b/lib/features/history/data/models/machine_history_response.g.dart
@@ -35,7 +35,7 @@ _HistoryContent _$HistoryContentFromJson(Map<String, dynamic> json) =>
       id: (json['id'] as num).toInt(),
       userRoomNumber: json['userRoomNumber'] as String,
       startTime: json['startTime'] as String,
-      completionTime: json['completionTime'] as String,
+      completionTime: json['completionTime'] as String?,
       status: json['status'] as String,
       createdAt: json['createdAt'] as String,
     );

--- a/lib/features/history/presentation/widgets/history_dialog.dart
+++ b/lib/features/history/presentation/widgets/history_dialog.dart
@@ -125,9 +125,12 @@ class _HistoryCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final status = HistoryStatusX.fromString(item.status);
-    final timeValue = DateTimeFormatter.formatToShortWithTime(
-      status == HistoryStatus.cancelled ? item.createdAt : item.completionTime,
-    );
+    final rawTime = status == HistoryStatus.cancelled
+        ? item.createdAt
+        : item.completionTime;
+    final timeValue = rawTime == null
+        ? '-'
+        : DateTimeFormatter.formatToShortWithTime(rawTime);
 
     return Container(
       padding: const EdgeInsets.all(12),


### PR DESCRIPTION

## 💡 개요
사용 기록(히스토리) 조회 응답에서 완료되지 않은 항목(예약중/확정/운전중)의 completionTime이 null로 내려올 때 파싱이 실패해 히스토리 전체가 안 불러와지던 문제를 수정합니다.

## 🔗 관련 이슈
Closes #239

## 📃 작업내용
- `HistoryContent.completionTime`을 non-null String에서 nullable(`String?`)로 변경
- build_runner로 freezed/json_serializable 코드 재생성
- `history_dialog.dart`에서 completionTime이 null인 경우 "-"로 표시하도록 분기 처리 추가

## 🔍 테스트 방법
- 당일 사용 기록에 예약중/확정/운전중 상태 항목이 포함된 세탁기의 히스토리 다이얼로그를 열어 정상적으로 목록이 표시되는지 확인
- 완료/취소 상태 항목은 기존과 동일하게 완료 시간/취소 시간이 표시되는지 확인
- `flutter analyze` 통과 확인

## 🖼️ 스크린샷


## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
- completionTime이 null일 때 표시를 "-"로 처리했는데, 다른 대체 텍스트가 낫다면 의견 부탁드립니다.

## ✅ 체크리스트
- [x] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [x] 불필요한 코드가 없는지 확인했습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [ ] 기존 기능이 정상적으로 작동하는지 확인했습니다.