### PR TITLE
🔀 :: (#241) - iOS 로그인 후 FCM 토큰 등록 대기 제거

### DIFF
--- a/lib/features/auth/data/repositories/auth_repository.dart
+++ b/lib/features/auth/data/repositories/auth_repository.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:washer/core/network/dio_client.dart';
@@ -27,12 +29,13 @@ class AuthRepository {
     final response = await _dataSource.login(
       LoginRequest(authCode: authCode, redirectUri: redirectUri),
     );
+
     await Future.wait([
       _storage.write(key: 'access_token', value: response.accessToken),
       _storage.write(key: 'refresh_token', value: response.refreshToken),
     ]);
 
-    await _alarmRepository.registerCurrentFcmToken();
+    unawaited(_alarmRepository.registerCurrentFcmToken());
   }
 
   Future<void> logout() async {


### PR DESCRIPTION
## 💡 개요

iOS에서 로그인 후 다음 화면으로 넘어가거나 데이터를 불러오는 시간이 오래 걸릴 수 있는 문제를 수정했습니다.

기존에는 `AuthRepository.login()`에서 로그인 API 성공 후 `accessToken` / `refreshToken`을 저장한 뒤,  
FCM/APNS 토큰 등록을 `await` 하고 있었습니다.

iOS에서는 APNS 토큰이 바로 준비되지 않을 수 있어 FCM 토큰 등록 과정에서 대기가 발생할 수 있고,  
이로 인해 로그인 성공 후 화면 전환이 지연되는 것처럼 보일 수 있었습니다.

로그인에 필수적인 토큰 저장은 기존처럼 `await` 유지하고,  
FCM 토큰 등록은 로그인 흐름을 막지 않도록 `unawaited`로 백그라운드 처리하도록 수정했습니다.

## 🔗 관련 이슈

Close #이슈번호

## 📃 작업내용

- `AuthRepository.login()`에서 FCM 토큰 등록 대기 제거
- `accessToken` / `refreshToken` 저장은 기존처럼 `await` 유지
- `_alarmRepository.registerCurrentFcmToken()`을 `unawaited`로 백그라운드 처리
- FCM/APNS 토큰 등록 대기로 인해 로그인 화면 전환이 지연되지 않도록 수정

## 🔍 테스트 방법

- `flutter analyze` 실행
- 로그인 성공 후 다음 화면으로 정상 이동하는지 확인
- FCM/APNS 토큰 등록 실패가 로그인 실패로 이어지지 않는지 확인
- 테스트용 로그를 통해 `login()` 함수가 FCM 토큰 등록을 기다리지 않고 종료되는지 확인

## 🖼️ 스크린샷

없음

## 🙋‍♂️ 질문사항

- FCM/APNS 토큰 등록을 로그인 흐름에서 분리한 방식이 적절한지 확인 부탁드립니다.
- `registerCurrentFcmToken()` 내부에서 예외를 처리하고 있는 상황에서 `unawaited` 사용이 괜찮은지 확인 부탁드립니다.

## ✅ 체크리스트

- [ ] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [ ] `flutter analyze`를 실행했습니다.
- [ ] 불필요한 테스트용 로그를 제거했습니다.
- [ ] 기존 로그인 흐름이 정상적으로 유지되는지 확인했습니다.
