### PR TITLE
🔀 :: (#245) - 릴리스 메타데이터 CI 검증 및 스토어 What's New 단일화

### DIFF
--- a/.github/workflows/flutter-ci.yaml
+++ b/.github/workflows/flutter-ci.yaml
@@ -7,6 +7,78 @@ on:
     branches: [ main, develop ]
 
 jobs:
+  # main 으로 가는 PR = 릴리스 PR. main push 시 스토어 CD 가 도는데
+  # pubspec 버전이나 What's New 갱신을 빠뜨리면 그대로 배포되므로 여기서 막는다.
+  # 릴리스가 아닌 PR(문서 수정 등)은 'skip-release-check' 라벨로 건너뛴다.
+  release_metadata_check:
+    name: 릴리스 메타데이터 검증 (버전 · What's New)
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.base_ref == 'main' &&
+      !contains(github.event.pull_request.labels.*.name, 'skip-release-check')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch base branch
+        run: git fetch --no-tags --depth=1 origin "${{ github.base_ref }}:refs/remotes/origin/base"
+
+      - name: Check pubspec version bump
+        run: |
+          read_version() { git show "$1:pubspec.yaml" | grep -m1 '^version:' | awk '{print $2}' | cut -d'+' -f1; }
+          OLD="$(read_version origin/base)"
+          NEW="$(read_version HEAD)"
+
+          if [ -z "$NEW" ]; then
+            echo "::error file=pubspec.yaml::pubspec.yaml 에서 version 을 읽지 못했습니다."
+            exit 1
+          fi
+
+          # 새 버전이 기존보다 크지 않으면 실패 (동일 · 다운그레이드 모두 차단)
+          if [ "$OLD" = "$NEW" ] || [ "$(printf '%s\n%s\n' "$OLD" "$NEW" | sort -V | tail -n 1)" != "$NEW" ]; then
+            echo "::error file=pubspec.yaml::앱 버전을 올려주세요. main=$OLD, PR=$NEW (pubspec.yaml 의 version: X.Y.Z)"
+            exit 1
+          fi
+          echo "버전 OK: $OLD → $NEW"
+
+      - name: Check What's New (release notes)
+        env:
+          # 한글 글자 수를 바이트가 아닌 문자 단위로 세기 위해 UTF-8 로케일 고정
+          LC_ALL: C.UTF-8
+        run: |
+          # 이 파일 하나가 App Store · Play Store 양쪽 What's New 의 단일 출처다.
+          NOTES_PATH="fastlane/metadata/ko/release_notes.txt"
+
+          if [ ! -s "$NOTES_PATH" ] || [ -z "$(tr -d '[:space:]' < "$NOTES_PATH")" ]; then
+            echo "::error file=$NOTES_PATH::What's New 가 비어 있습니다. 이번 릴리스 내용을 작성해주세요."
+            exit 1
+          fi
+
+          # Play Store 는 로케일당 500자 제한 (iOS 는 4000자 → 빡빡한 쪽에 맞춘다).
+          # 배포 중 실패하지 않도록 PR 시점에 미리 막는다.
+          COUNT="$(wc -m < "$NOTES_PATH" | tr -d ' ')"
+          if [ "$COUNT" -gt 500 ]; then
+            echo "::error file=$NOTES_PATH::What's New 가 ${COUNT}자로 Play Store 제한(500자)을 넘습니다."
+            exit 1
+          fi
+
+          # 지난 릴리스 문구를 그대로 두고 배포하는 실수를 막는다.
+          if git diff --quiet origin/base HEAD -- "$NOTES_PATH"; then
+            echo "::error file=$NOTES_PATH::What's New 가 main 과 동일합니다. 이번 릴리스 내용으로 갱신해주세요."
+            exit 1
+          fi
+          echo "What's New OK:"
+          cat "$NOTES_PATH"
+
+      # Fastfile 문법 오류는 배포 중에 터지면 손해가 크므로 PR 에서 잡는다.
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
+      - name: Syntax check Fastfile
+        run: ruby -c fastlane/Fastfile
+
   flutter_test_and_build:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && contains(github.event.head_commit.message, '[CI]'))

--- a/.github/workflows/flutter-ci.yaml
+++ b/.github/workflows/flutter-ci.yaml
@@ -7,6 +7,19 @@ on:
     branches: [ main, develop ]
 
 jobs:
+  # Fastfile 문법 오류는 양쪽 스토어 배포를 동시에 깨뜨리므로 모든 PR 에서 잡는다.
+  # (릴리스 검증과 무관하니 skip-release-check 라벨에 영향받지 않도록 별도 잡으로 둔다)
+  fastfile_check:
+    name: Fastfile 문법 검사
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+      - run: ruby -c fastlane/Fastfile
+
   # main 으로 가는 PR = 릴리스 PR. main push 시 스토어 CD 가 도는데
   # pubspec 버전이나 What's New 갱신을 빠뜨리면 그대로 배포되므로 여기서 막는다.
   # 릴리스가 아닌 PR(문서 수정 등)은 'skip-release-check' 라벨로 건너뛴다.
@@ -69,15 +82,6 @@ jobs:
           fi
           echo "What's New OK:"
           cat "$NOTES_PATH"
-
-      # Fastfile 문법 오류는 배포 중에 터지면 손해가 크므로 PR 에서 잡는다.
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.2'
-
-      - name: Syntax check Fastfile
-        run: ruby -c fastlane/Fastfile
 
   flutter_test_and_build:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -1,7 +1,8 @@
 name: Release - iOS App Store
 
 # main 에 push(머지)되면 App Store 심사에 자동 제출한다.
-# - 마케팅 버전은 App Store Connect 최신 버전 +패치로 자동 증가 (Fastfile resolve_next_appstore_version)
+# - 마케팅 버전은 pubspec.yaml 의 version (Android 와 동일 출처)
+#   ASC 최고 버전 이하면 archive 전에 실패한다 (Fastfile assert_appstore_version_available)
 # - 릴리스 노트는 머지 커밋 메시지(PR 제목)에서 가져옴, 없으면 기본 문구
 # TestFlight 배포는 cd-ios.yml 이 따로 담당(같은 main push 로 동시 동작).
 # ⚠️ Apple 은 한 번에 버전 1개만 심사 → main 은 릴리스용으로 사용 권장.
@@ -134,30 +135,31 @@ jobs:
           fi
           echo "IOS_PROVISIONING_PROFILE_UUID=$PROFILE_UUID" >> "$GITHUB_ENV"
 
-      - name: Resolve build number
+      - name: Resolve iOS version metadata
         run: |
-          # 마케팅 버전은 Fastfile 이 App Store Connect 조회로 자동 결정한다.
-          # 여기선 빌드번호만 run number 로 고정(App Store 빌드 중복 방지).
+          # 마케팅 버전은 Android 와 동일하게 pubspec.yaml 을 단일 출처로 쓴다.
+          VERSION_LINE="$(grep '^version:' pubspec.yaml | head -n 1 | awk '{print $2}')"
+          VERSION_NAME="${VERSION_LINE%%+*}"
+
+          if [ -z "$VERSION_NAME" ]; then
+            echo "::error::Unable to parse version from pubspec.yaml"
+            exit 1
+          fi
+
+          echo "IOS_VERSION_NAME=$VERSION_NAME" >> "$GITHUB_ENV"
+          # 빌드번호는 run number 로 고정(App Store 빌드 중복 방지).
           echo "IOS_BUILD_NUMBER=${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
 
-      - name: Prepare release notes
+      - name: Verify release notes
         run: |
-          # What's New 우선순위:
-          # 1) 레포에 커밋된 fastlane/metadata/ko/release_notes.txt 에 내용이 있으면 그걸 그대로 사용.
-          #    (App Store 심사용 릴리스 노트를 명시적으로 관리 — 빈약한 노트로 인한 반려 방지)
-          # 2) 없거나 비어있으면 머지 커밋 메시지 본문(보통 PR 제목)을 사용.
-          # 3) 그것도 비면 기본 문구.
+          # What's New 는 레포에 커밋된 이 파일이 단일 출처다. (Android/supply 도 같은 파일을 씀)
+          # 과거엔 없으면 커밋 메시지로 자동 생성했지만, 그러면 Android 와 내용이 갈리고
+          # 빈약한 노트로 심사 반려될 수 있어 없으면 실패시킨다.
+          # (main 으로 가는 PR 은 flutter-ci.yaml 의 release_metadata_check 가 미리 검증)
           NOTES_PATH="fastlane/metadata/ko/release_notes.txt"
-          if [ -f "$NOTES_PATH" ] && [ -n "$(tr -d '[:space:]' < "$NOTES_PATH")" ]; then
-            echo "커밋된 $NOTES_PATH 를 What's New 로 사용합니다."
-          else
-            NOTES="$(git log -1 --format=%b HEAD | sed '/^[[:space:]]*$/d' | head -n 10)"
-            if [ -z "$(printf '%s' "$NOTES" | tr -d '[:space:]')" ]; then
-              NOTES="버그 수정 및 안정성 개선"
-            fi
-            # App Store 등록 언어(ko)에 What's New 작성. (등록 언어 추가 시 디렉터리 추가 필요)
-            mkdir -p fastlane/metadata/ko
-            printf '%s\n' "$NOTES" > "$NOTES_PATH"
+          if [ ! -s "$NOTES_PATH" ] || [ -z "$(tr -d '[:space:]' < "$NOTES_PATH")" ]; then
+            echo "::error file=$NOTES_PATH::What's New 가 비어 있습니다. 이번 릴리스 내용을 작성해주세요."
+            exit 1
           fi
           echo "----- release_notes (ko) -----"
           cat "$NOTES_PATH"

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ android/key.properties
 .codex/
 .omx/
 .omc/
+
+# Play Store changelog — 빌드 시점에 fastlane/metadata/ko/release_notes.txt 에서 생성됨 (커밋 금지)
+fastlane/metadata/android/

--- a/docs/cd_handover.md
+++ b/docs/cd_handover.md
@@ -1,0 +1,165 @@
+# CD 인수인계 문서
+
+`main` 브랜치 배포 파이프라인을 넘겨받을 사람이 (1) **지금 CD를 어떻게 돌리는지**, (2) **무엇을 같이 넘겨받아야 하는지**를 한 번에 알 수 있게 정리한 문서.
+
+> ⚠️ `docs/mobile_store_cd.md`는 낡았습니다 (존재하지 않는 워크플로우/시크릿명 참조). **이 문서를 기준**으로 하세요.
+
+---
+
+## 1. 현재 CD 구조
+
+실제로 존재하는 워크플로우는 3개뿐입니다 (`.github/workflows/`).
+
+| 파일 | 트리거 | 하는 일 |
+|------|--------|---------|
+| `flutter-ci.yaml` | PR(main/develop), `[CI]` 포함한 main push | test / analyze / APK 빌드 + Discord 알림 |
+| `release-android.yml` | main push, 수동 | AAB 빌드·서명 → Google Play **production** 트랙 정식 출시 |
+| `release-ios.yml` | main push, 수동 | IPA 빌드·서명 → App Store **심사 자동 제출** |
+
+iOS는 GitHub Actions 외에 **Xcode Cloud** 경로도 있습니다: `ios/ci_scripts/ci_post_clone.sh`가 `ENV_PRODUCTION`/`ENV_DEVELOPMENT` 환경변수로 `.env.*`를 만들고 Flutter/Pods를 세팅. Xcode Cloud를 쓴다면 거기에도 같은 env 값을 등록해야 합니다.
+
+- 배포 실행은 Fastlane 이 담당: iOS `release_appstore` / Android `release_play_store` lane (`fastlane/Fastfile`).
+- 앱 식별자: `com.washer.v2` (iOS/Android 공통), Apple Team ID `UB2797YAAH` (`fastlane/Appfile`).
+- ⚠️ 릴리스 워크플로우 주석은 베타(TestFlight/internal)용 `cd-ios.yml` / `cd-android.yml`을 언급하지만 **현재 레포에 그 파일들은 없습니다.** 베타 배포가 필요하면 새로 만들어야 합니다 (lane은 이미 있음: `upload_testflight` / `upload_play_store`).
+
+---
+
+## 2. 지금 CD 돌리는 법
+
+### 자동 (평상시)
+`main`에 push(=PR 머지)되면 `release-android.yml`·`release-ios.yml`이 자동 실행 → 그대로 **스토어에 실배포**됩니다.
+- Android: Play production 트랙 즉시 정식 출시.
+- iOS: App Store 심사 자동 제출. 심사 승인 후 **출시는 수동**(`automatic_release: false`). 이미 심사 대기/진행 중 버전이 있으면 이번 제출은 자동 skip.
+
+### 수동 (테스트/재실행) — `workflow_dispatch`
+GitHub → **Actions** 탭 → 워크플로우 선택 → **Run workflow**.
+- `dry_run` 입력 (기본값 **true**): 빌드·서명까지만 하고 **스토어 업로드는 건너뜀**. 시크릿/서명 설정 검증용으로 안전.
+- 실제로 수동 배포하려면 `dry_run`을 **false**로 바꿔서 실행.
+
+### 버전 규칙
+- version name: **iOS·Android 모두** `pubspec.yaml`의 `version:` (예: `1.1.3+5` → `1.1.3`)에서 읽음. 여기가 단일 출처.
+- iOS build number: `GITHUB_RUN_NUMBER`.
+- Android versionCode: `1000 + GITHUB_RUN_NUMBER` (과거 내부트랙 업로드 코드와 충돌 방지용 오프셋 — 낮추지 말 것).
+- pubspec의 `+5` (빌드번호)는 **어디에도 안 쓰임** — 양쪽 다 run number로 덮어씀. 올려도 되고 안 올려도 무방.
+- pubspec 버전이 App Store Connect 최고 버전 이하면 archive **전에** 실패한다(Fastfile `assert_appstore_version_available`). 에러 메시지에 올려야 할 버전이 찍히므로 pubspec을 그 위로 올리고 재실행.
+
+### 릴리스 누락 방지 (CI)
+`main`으로 가는 PR에는 `release_metadata_check` 잡(`flutter-ci.yaml`)이 돌아 아래를 강제합니다.
+- `pubspec.yaml`의 version name이 main보다 **높을 것** (동일·다운그레이드 차단).
+- `fastlane/metadata/ko/release_notes.txt`(What's New)가 비어있지 않고 main과 **다를 것**.
+
+릴리스가 아닌 PR(문서 수정 등)은 PR에 `skip-release-check` 라벨을 달면 건너뜁니다.
+⚠️ Branch protection에서 이 잡을 **required check**로 지정해야 실제로 머지가 막힙니다.
+
+### What's New — 파일 하나로 양쪽 스토어 자동 반영
+**`fastlane/metadata/ko/release_notes.txt` 이 파일만 고치면 App Store · Play Store 양쪽에 동일하게 올라갑니다.** 여기가 단일 출처입니다.
+
+- iOS(deliver): 이 경로를 그대로 읽습니다.
+- Android(supply): 경로 규칙이 `metadata/android/ko-KR/changelogs/<versionCode>.txt`로 달라서, versionCode가 확정되는 **빌드 시점에 위 파일에서 복사 생성**합니다(Fastfile `prepare_play_changelog`). 생성물은 `.gitignore` 처리 — 커밋하지 마세요.
+- ⚠️ supply는 해당 versionCode 파일이 없으면 **에러 없이 빈 릴리스 노트로 업로드**합니다(조용한 실패). 그래서 lane에서 존재·내용을 명시적으로 검증합니다.
+- **글자 수 제한 500자** (Play 기준, iOS는 4000자라 빡빡한 쪽에 맞춤). PR CI에서 미리 막고, 빌드 시점에도 한 번 더 검사합니다.
+- 등록 언어를 늘리려면 iOS는 `metadata/<locale>/`, Android는 `PLAY_CHANGELOG_LOCALE` 추가가 필요합니다(현재 한국어만).
+
+### ⚠️ iOS 심사 스킵 시 What's New 누적 작성
+- iOS 제출이 스킵되면(이전 버전이 `WAITING_FOR_REVIEW`/`IN_REVIEW`/`PENDING_APPLE_RELEASE`/`PROCESSING_FOR_APP_STORE`) **그때 쓴 What's New는 App Store에 반영되지 않습니다.** 다음 릴리스 노트에 **이번 변경사항까지 누적**해서 쓰세요. 스킵되면 Actions 실행 요약에 어떤 버전·어떤 상태 때문인지 경고가 뜹니다.
+- 특히 `PENDING_APPLE_RELEASE`(심사 승인 후 수동 출시 대기)를 방치하면 **이후 iOS 배포가 계속 조용히 스킵**됩니다. 승인 알림을 받으면 App Store Connect에서 출시 버튼을 눌러 상태를 비워두세요.
+
+---
+
+## 3. 인수인계 항목 (⚠️ 핵심)
+
+### 3-1. GitHub Secrets — Settings → Secrets and variables → Actions
+
+새 담당자가 레포/Actions 접근 권한을 받아야 하고, 조직/포크가 바뀌면 **아래 시크릿을 전부 다시 등록**해야 합니다. (전부 GitHub *Secrets*, Variables 아님.)
+
+**Android (`release-android.yml`)**
+| Secret | 내용 | 출처 |
+|--------|------|------|
+| `GOOGLE_PLAY_JSON_KEY` | Play Console 서비스 계정 JSON 전체 | Play Console → 설정 → API 액세스 → 서비스 계정 |
+| `ANDROID_KEYSTORE_BASE64` | `android/upload-keystore.jks`를 base64 인코딩 | 로컬 키스토어 파일 (아래 3-2) |
+| `ANDROID_KEY_PROPERTIES` | `android/key.properties` 전체 내용 | 로컬 파일 (아래 3-2) |
+| `ANDROID_GOOGLE_SERVICES_JSON` | `android/app/google-services.json` 전체 | Firebase 콘솔 |
+| `ENV_PRODUCTION` | `.env.production` 전체 내용 | 로컬 파일 (아래 3-2) |
+| `ENV_DEVELOPMENT` | `.env.development` 전체 내용 | 로컬 파일 (아래 3-2) |
+
+> `GOOGLE_PLAY_JSON_KEY`가 없으면 guard job이 production 배포를 조용히 skip합니다(워크플로우는 초록). 실배포하려면 반드시 등록.
+
+**iOS (`release-ios.yml`)**
+| Secret | 내용 | 출처 |
+|--------|------|------|
+| `ENV_PRODUCTION` | `.env.production` 전체 | 로컬 파일 |
+| `ENV_DEVELOPMENT` | `.env.development` 전체 | 로컬 파일 |
+| `IOS_BUILD_CERTIFICATE_BASE64` | Apple Distribution `.p12`를 base64 | 키체인에서 export |
+| `IOS_P12_PASSWORD` | 위 `.p12` export 비밀번호 | export 시 지정한 값 |
+| `IOS_BUILD_PROVISION_PROFILE_BASE64` | App Store provisioning profile `.mobileprovision`를 base64 | Apple Developer |
+| `IOS_KEYCHAIN_PASSWORD` | CI 임시 키체인 비밀번호 (아무 값) | 임의 지정 |
+| `APP_STORE_CONNECT_API_KEY` | App Store Connect API 키 `.p8` 원문 전체 | ASC → 사용자 및 액세스 → 통합 → 키 |
+| `APP_STORE_CONNECT_KEY_ID` | 위 API 키의 Key ID | ASC |
+| `APP_STORE_CONNECT_ISSUER_ID` | ASC Issuer ID | ASC |
+
+**CI (`flutter-ci.yaml`)**
+| Secret | 내용 |
+|--------|------|
+| `DISCORD_WEBHOOK` | CI 결과 알림용 Discord 웹훅 URL (없으면 알림만 skip) |
+
+### 3-2. 로컬 시크릿 파일 — Infisical로 관리 (git에 없음)
+
+아래 파일들은 전부 `.gitignore` 처리돼 레포에 **없고**, **Infisical**에 base64로 저장돼 있습니다. 파일을 손으로 주고받는 게 아니라 **Infisical 접근 권한을 넘겨받고 스크립트로 복원**합니다.
+
+```powershell
+infisical login          # 최초 1회
+infisical init           # 레포에 프로젝트 연결(최초 1회)
+./scripts/secrets-pull.ps1            # dev 환경 시크릿을 제자리에 복원
+./scripts/secrets-pull.ps1 -Env prod  # prod 환경
+```
+
+`scripts/secrets-map.ps1`이 시크릿명↔경로 매핑을 정의하며, 현재 관리 대상은:
+
+| Infisical Secret | 파일 경로 |
+|------------------|-----------|
+| `ENV_DEVELOPMENT` | `.env.development` |
+| `ENV_PRODUCTION` | `.env.production` |
+| `ANDROID_GOOGLE_SERVICES_JSON` | `android/app/google-services.json` |
+| `IOS_GOOGLE_SERVICE_INFO_PLIST` | `ios/Runner/GoogleService-Info.plist` |
+| `ANDROID_UPLOAD_KEYSTORE_JKS` | `android/upload-keystore.jks` |
+| `ANDROID_KEY_PROPERTIES` | `android/key.properties` |
+
+- 로컬에서 파일을 바꿨으면 `./scripts/secrets-push.ps1 [-Env prod]`로 Infisical에 다시 올립니다. 새 시크릿 파일을 추가하려면 `secrets-map.ps1`에 줄 하나 추가.
+- ⚠️ **iOS 배포 서명 자료(.p12 / .mobileprovision / ASC .p8)와 Play 서비스 계정 JSON은 이 매핑에 없습니다.** 이건 GitHub Secrets(3-1)에만 있고 Infisical엔 없으니 별도 안전 채널로 인수인계해야 합니다.
+- `.env.production`/`.env.development` 키 형식은 `.env.*.example` 참고 (`API_BASE_URL`, `REFRESH_TOKEN_ENDPOINT`, `OAUTH_BASE_URL`, `OAUTH_CLIENT_ID`).
+- `upload-keystore.jks`는 **분실 시 Play 앱 서명 복구 불가** → Infisical 외 백업도 권장.
+
+### 3-3. 계정 접근 권한
+
+- Apple Developer / App Store Connect (Team `UB2797YAAH`) — Admin 또는 App Manager 초대.
+- Google Play Console — 서비스 계정 + 콘솔 사용자 초대.
+- Firebase 프로젝트.
+- GitHub 레포 + Actions Secrets 편집 권한.
+- **Infisical** 프로젝트 접근 (로컬 시크릿 복원용, 3-2 참고).
+
+---
+
+## 4. 로컬에서 검증하는 법
+
+CI를 건드리지 않고 빌드/서명만 재현:
+
+```powershell
+./scripts/secrets-pull.ps1           # 먼저 시크릿 파일 복원 (Infisical, 3-2 참고)
+bundle install                       # fastlane 등 gem 설치
+# iOS: 스토어 업로드 없이 archive 검증
+$env:DRY_RUN="true"; bundle exec fastlane ios release_appstore
+# Android: 스토어 업로드 없이 AAB 빌드 검증
+$env:DRY_RUN="true"; bundle exec fastlane android release_play_store
+```
+
+- Infisical이 아직 없으면 `scripts/ensure_env_files.sh`로 `.env.*`를 example에서 만들 수 있지만 **플레이스홀더 값**이라 실제 서버 연동은 안 됩니다.
+- `.env.*`, 서명 파일, `IOS_BUILD_NUMBER`/`IOS_PROVISIONING_PROFILE_UUID` 등 워크플로우가 세팅하는 환경변수가 로컬에도 있어야 완전 재현됩니다. 서명이 필요 없는 순수 빌드만 볼 거면 `fvm flutter build appbundle` / `build ios --no-codesign`.
+
+---
+
+## 5. 알려진 이슈 / 주의
+
+- **커밋된 비밀 위험**: `android/key.properties`에 실제 비밀번호(`washer1234`)가, 그리고 키스토어가 로컬에 평문으로 있음. 현재는 gitignore로 커밋만 막혀 있으니, 조직 이관 시 키스토어/비밀번호 **로테이션 검토** 권장.
+- **낡은 문서**: `docs/mobile_store_cd.md`는 실제와 불일치. 이 문서로 대체됨.
+- **신규 앱 최초 출시**: Play production은 콘솔에서 최초 1회 수동 출시해야 이후 API 출시가 됩니다 (release-android.yml 상단 주석 참고).
+- **Apple 동시 심사 1개**: main에 자주 머지하면 중복 심사 제출이 막히므로 자동 skip 처리됨. main은 릴리스용으로 운용 권장.

--- a/docs/mobile_store_cd.md
+++ b/docs/mobile_store_cd.md
@@ -1,5 +1,8 @@
 # Mobile Store CD Guide
 
+> ⚠️ **이 문서는 낡았습니다** (여기 적힌 워크플로우/시크릿명은 현재 레포와 불일치). 최신 배포/인수인계 내용은 [`docs/cd_handover.md`](./cd_handover.md)를 보세요.
+
+
 `main` 브랜치에 push되면 플랫폼별 GitHub Actions 워크플로가 Fastlane으로 스토어 배포를 실행합니다.
 
 - iOS: `.github/workflows/ios-testflight.yaml` — IPA 빌드 후 TestFlight 업로드

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,5 +1,12 @@
 WORKSPACE = ENV.fetch("GITHUB_WORKSPACE", File.expand_path("..", __dir__))
 
+# What's New 단일 출처. iOS(deliver)는 이 경로를 그대로 읽고,
+# Android(supply)는 versionCode 규칙이 달라 빌드 시점에 여기서 복사해 간다.
+# (prepare_play_changelog 참고 — 이 파일만 고치면 양쪽 스토어에 동일하게 반영된다)
+RELEASE_NOTES_PATH = "fastlane/metadata/ko/release_notes.txt"
+PLAY_CHANGELOG_LOCALE = "ko-KR"
+PLAY_CHANGELOG_LIMIT = 500
+
 default_platform(:ios)
 
 platform :ios do
@@ -46,15 +53,25 @@ platform :ios do
 
       # 이미 심사 대기/진행 중인 버전이 있으면 새 제출을 건너뛴다.
       # (Apple 은 한 번에 한 버전만 심사 → main 에 자주 머지돼도 실패하지 않고 스킵)
-      if appstore_review_in_progress
-        UI.important("이미 심사 대기/진행 중인 버전이 있어 이번 App Store 제출은 건너뜁니다.")
+      blocking = blocking_appstore_version
+      if blocking
+        # 스킵되면 이번 release_notes.txt 는 App Store 에 올라가지 않는다.
+        # 조용히 넘어가면 다음 릴리스에서 노트를 덮어써 누락되므로 Actions 요약에 경고로 띄운다.
+        msg = "iOS 제출 건너뜀 — #{blocking.version_string} 이 #{blocking.app_store_state} 상태입니다. " \
+              "이번 What's New 는 App Store 에 반영되지 않았으니, " \
+              "다음 릴리스 노트에 이번 변경사항까지 누적해서 작성하세요."
+        UI.important(msg)
+        puts "::warning::#{msg}"
         next
       end
     end
 
-    # 마케팅 버전: 실배포는 App Store Connect 최고 버전 +패치로 자동 증가,
-    # dry-run 은 ASC 조회 없이 IOS_VERSION_NAME(없으면 0.0.1)으로 빌드만 한다.
-    version_name = dry_run ? ENV.fetch("IOS_VERSION_NAME", "0.0.1") : resolve_next_appstore_version
+    # 마케팅 버전은 Android 와 동일하게 pubspec.yaml 을 단일 출처로 쓴다.
+    # (워크플로우가 pubspec 에서 읽어 IOS_VERSION_NAME 으로 주입)
+    version_name = ENV.fetch("IOS_VERSION_NAME")
+
+    # ASC 최고 버전 이하면 업로드가 거부되므로 긴 archive 전에 미리 막는다.
+    assert_appstore_version_available(version_name: version_name) unless dry_run
 
     build_signed_ipa(
       version_name: version_name,
@@ -123,11 +140,13 @@ platform :ios do
     )
   end
 
-  # 심사 대기/진행 중이라 새 제출이 막히는 버전이 있는지 확인한다. (setup_connect_api 선행 필요)
-  private_lane :appstore_review_in_progress do
+  # 새 제출을 막는 상태의 버전을 찾아 반환한다(없으면 nil). (setup_connect_api 선행 필요)
+  # PENDING_APPLE_RELEASE = 심사 승인됐지만 수동 출시(automatic_release: false) 대기 중.
+  # 이 상태를 방치하면 이후 iOS 배포가 계속 skip 되므로 호출부에서 상태를 명시해 알린다.
+  private_lane :blocking_appstore_version do
     app = Spaceship::ConnectAPI::App.find(BUNDLE_ID)
     if app.nil?
-      false
+      nil
     else
       blocking = %w[
         WAITING_FOR_REVIEW
@@ -135,27 +154,29 @@ platform :ios do
         PENDING_APPLE_RELEASE
         PROCESSING_FOR_APP_STORE
       ]
-      app.get_app_store_versions.any? { |v| blocking.include?(v.app_store_state) }
+      app.get_app_store_versions.find { |v| blocking.include?(v.app_store_state) }
     end
   end
 
-  # App Store Connect 의 현재 최고 마케팅 버전을 조회해 patch +1 한 버전 문자열을 반환한다.
-  # (라이브/심사중/편집중 버전을 모두 포함한 최댓값 기준 → 진행 중 버전과 충돌 방지)
-  # setup_connect_api 선행 필요.
-  private_lane :resolve_next_appstore_version do
+  # pubspec 버전이 App Store Connect 에 올릴 수 있는 값인지 확인한다.
+  # (라이브/심사중/편집중 버전을 모두 포함한 최댓값 기준 → 이하면 Apple 이 거부)
+  # 실패 시 archive 전에 끊어 20분짜리 빌드를 낭비하지 않는다. setup_connect_api 선행 필요.
+  private_lane :assert_appstore_version_available do |options|
+    version_name = options.fetch(:version_name)
+
     app = Spaceship::ConnectAPI::App.find(BUNDLE_ID)
     UI.user_error!("App #{BUNDLE_ID} 를 App Store Connect 에서 찾지 못했습니다") if app.nil?
 
-    versions = app.get_app_store_versions
-    current = versions.map { |v| Gem::Version.new(v.version_string) }.max || Gem::Version.new("1.0.0")
+    current = app.get_app_store_versions.map { |v| Gem::Version.new(v.version_string) }.max
 
-    seg = current.segments.dup
-    seg << 0 while seg.size < 3
-    seg[2] += 1
-    next_version = seg[0, 3].join(".")
+    if current && Gem::Version.new(version_name) <= current
+      UI.user_error!(
+        "pubspec 버전 #{version_name} 이 App Store 최고 버전 #{current} 이하입니다. " \
+        "pubspec.yaml 의 version 을 #{current} 보다 높게 올려주세요."
+      )
+    end
 
-    UI.message("App Store 다음 버전 자동 결정: #{next_version} (현재 최고 #{current})")
-    next_version
+    UI.message("App Store 버전 확인 OK: #{version_name} (현재 최고 #{current || '없음'})")
   end
 
   # Flutter 빌드 + 수동 서명 아카이브로 app-store IPA 를 만든다. (TestFlight·App Store 공용)
@@ -233,6 +254,9 @@ platform :android do
     build_number = ENV.fetch("ANDROID_BUILD_NUMBER")
     version_name = ENV.fetch("ANDROID_VERSION_NAME")
 
+    # What's New 는 iOS 와 같은 파일을 단일 출처로 쓴다. (빌드 전에 검증 → 긴 빌드 낭비 방지)
+    metadata_path = prepare_play_changelog(build_number: build_number)
+
     sh(
       [
         "fvm", "flutter", "build", "appbundle",
@@ -261,12 +285,45 @@ platform :android do
       aab: aab_path,
       skip_upload_apk: true,
       skip_upload_metadata: true,
-      skip_upload_changelogs: true,
+      skip_upload_changelogs: false,
       skip_upload_images: true,
-      skip_upload_screenshots: true
+      skip_upload_screenshots: true,
+      metadata_path: metadata_path
     }
     play_store_params[:release_status] = release_status unless release_status.nil?
 
     upload_to_play_store(**play_store_params)
+  end
+
+  # iOS 와 공유하는 What's New 원본(fastlane/metadata/ko/release_notes.txt)을
+  # supply 규칙인 <metadata_path>/<locale>/changelogs/<versionCode>.txt 로 복사한다.
+  # versionCode 는 실행마다 달라져(1000+run number) 커밋 시점에 알 수 없으므로 빌드 시점에 생성한다.
+  # ⚠️ supply 는 해당 versionCode 파일이 없으면 에러 없이 "빈 릴리스 노트"로 업로드하므로
+  #    (조용한 실패) 여기서 존재·내용을 명시적으로 검증한다.
+  # 반환값: upload_to_play_store 에 넘길 metadata_path
+  private_lane :prepare_play_changelog do |options|
+    build_number = options.fetch(:build_number)
+
+    notes_path = File.join(WORKSPACE, RELEASE_NOTES_PATH)
+    UI.user_error!("What's New 원본이 없습니다: #{RELEASE_NOTES_PATH}") unless File.exist?(notes_path)
+
+    # 인코딩을 명시하지 않으면 러너 로케일에 따라 length 가 바이트 수로 세어져 한글에서 오판한다.
+    notes = File.read(notes_path, encoding: "UTF-8").strip
+    UI.user_error!("What's New 가 비어 있습니다: #{RELEASE_NOTES_PATH}") if notes.empty?
+
+    # Play Store 는 로케일당 500자 제한 (초과 시 업로드 거부). iOS(4000자)보다 빡빡한 쪽에 맞춘다.
+    if notes.length > PLAY_CHANGELOG_LIMIT
+      UI.user_error!(
+        "What's New 가 #{notes.length}자로 Play Store 제한(#{PLAY_CHANGELOG_LIMIT}자)을 넘습니다: #{RELEASE_NOTES_PATH}"
+      )
+    end
+
+    metadata_path = File.join(WORKSPACE, "fastlane", "metadata", "android")
+    changelog_dir = File.join(metadata_path, PLAY_CHANGELOG_LOCALE, "changelogs")
+    FileUtils.mkdir_p(changelog_dir)
+    File.write(File.join(changelog_dir, "#{build_number}.txt"), notes)
+
+    UI.message("Play changelog 생성: #{PLAY_CHANGELOG_LOCALE}/changelogs/#{build_number}.txt (#{notes.length}자)")
+    metadata_path
   end
 end


### PR DESCRIPTION
## 💡 개요

`main` push 시 스토어 CD가 그대로 실배포되는데, 앱 버전 bump와 What's New 갱신을 사람이 까먹어도 막을 게 없었습니다. PR 단계에서 검증하도록 하고, 스토어별로 갈라져 있던 What's New 관리를 **파일 하나**로 합쳤습니다.

## 🔗 관련 이슈

Close #245

## 📃 작업내용

### 1. main PR 검증 게이트 (`flutter-ci.yaml`)
- `pubspec.yaml` 버전이 main보다 **높아야** 통과 (동일·다운그레이드 차단)
- `release_notes.txt`가 비어있지 않고 main과 **달라야** 통과
- Play 500자 제한을 배포 중이 아닌 **PR 시점**에 검사
- `ruby -c fastlane/Fastfile` — 문법 오류가 배포 중에 터지지 않도록

### 2. What's New 단일화 + Play 자동화
**`fastlane/metadata/ko/release_notes.txt` 하나만 고치면 양쪽 스토어에 반영됩니다.**
- iOS(deliver)는 이 경로를 그대로 읽고, Android(supply)는 경로 규칙이 달라(`metadata/android/ko-KR/changelogs/<versionCode>.txt`) 빌드 시점에 복사 생성
- versionCode가 `1000+run_number`라 커밋 시점엔 알 수 없어 런타임 생성이 유일한 방법입니다. 생성물은 `.gitignore` 처리
- ⚠️ **supply는 versionCode 파일이 없으면 에러 없이 빈 노트로 업로드**합니다(조용한 실패). lane에서 존재·내용·길이를 명시 검증

### 3. iOS 버전을 pubspec 기준으로 통일
- 기존: App Store Connect 최고 버전 +패치로 자동 증가 → pubspec과 무관하게 흘러가 양 스토어 버전이 어긋남
- 변경: Android와 동일하게 pubspec을 단일 출처로 사용. ASC 최고 버전 이하면 **20분짜리 archive 전에** 끊고 올려야 할 버전을 에러에 표시

### 4. iOS 심사 스킵을 눈에 보이게
- 스킵 시 어떤 버전이 어떤 상태로 막았는지 Actions 요약에 경고로 노출
- 특히 `PENDING_APPLE_RELEASE`(승인 후 수동 출시 대기)를 방치하면 **이후 iOS 배포가 계속 조용히 스킵**됩니다. 그때 쓴 What's New는 반영되지 않으므로 다음 릴리스 노트에 누적 작성이 필요하다는 안내를 함께 출력

## 🔍 테스트 방법

- 버전 비교 로직: `1.1.3→1.1.3` 차단, `1.1.9→1.1.10` 통과, `1.2.0→1.1.9` 차단 실측
- 500자 게이트: 한글 501자 차단 / 현재 노트 179자(431바이트) 통과 — `LC_ALL=C.UTF-8`로 바이트가 아닌 글자 수로 셈
- 워크플로우 YAML 3개 파싱 확인, `.gitignore` 동작 확인
- supply의 `skip_upload_metadata`/`skip_upload_changelogs` 독립 동작과 경로 규칙은 fastlane 소스에서 확인
- **미검증**: Fastfile은 로컬에 ruby가 없어 문법 검사를 못 돌렸습니다. 이 PR의 `ruby -c` 스텝이 첫 검증입니다. 실행 검증은 `release-android.yml`을 `dry_run=true`로 돌리면 changelog 생성·검증까지 타고 업로드만 건너뜁니다

## 🙋‍♂️ 질문사항

- 이 PR은 **자기가 만든 게이트에 스스로 걸려서** `skip-release-check` 라벨을 붙였습니다(CI/CD 설정 변경이라 앱 릴리스가 아님). 탈출구가 실제로 동작하는지 확인차 겸사겸사입니다.
- 머지 후 **Branch protection에서 `release_metadata_check`를 required check로 지정**해야 실제로 머지가 막힙니다.
- iOS 버전 출처가 바뀌었으니, App Store Connect 최고 버전이 `1.1.4`보다 앞서 있지 않은지 확인 부탁드립니다. 앞서 있으면 다음 배포가 (안전하게, 빌드 전에) 끊깁니다.

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [x] 불필요한 코드가 없는지 확인했습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [x] 기존 기능이 정상적으로 작동하는지 확인했습니다.
