### PR TITLE
🔀 :: (#249) - iOS 심사 승인 후 자동 출시로 전환

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -90,7 +90,12 @@ platform :ios do
 
     # 바이너리를 App Store Connect 에 올리고 심사까지 자동 제출한다.
     # - submit_for_review: 심사 제출까지 자동
-    # - automatic_release: false → 심사 승인 후 출시는 수동(안전). 승인 즉시 자동 출시하려면 true.
+    # - automatic_release: true → 심사 승인 즉시 자동 출시.
+    #   false(수동 출시)였을 때 승인된 버전이 PENDING_DEVELOPER_RELEASE 로 남았고,
+    #   Apple 은 in-flight 버전이 있으면 새 버전 생성을 거부해 사람이 출시 버튼을 누를 때까지
+    #   다음 배포가 계속 막혔다. (8/2·8/5 연속 실패 → guard 추가 후에는 조용히 스킵)
+    #   출시 시점을 직접 고르고 싶어지면 false 로 되돌리되, 그때는 승인될 때마다
+    #   App Store Connect 에서 출시를 눌러야 다음 배포가 나간다는 걸 감수해야 한다.
     # - skip_metadata: false → fastlane/metadata/<locale>/release_notes.txt 의 "What's New" 만 업로드.
     #   (다른 메타데이터 파일이 없으면 deliver 가 해당 필드를 건드리지 않음 = 기존 값 유지)
     #   release_notes.txt 는 release-ios.yml 이 머지 커밋 메시지로부터 빌드 직전에 생성한다.
@@ -100,7 +105,7 @@ platform :ios do
       api_key: api_key,
       app_identifier: BUNDLE_ID,
       submit_for_review: true,
-      automatic_release: false,
+      automatic_release: true,
       force: true,
       run_precheck_before_submit: false,
       skip_metadata: false,
@@ -151,6 +156,8 @@ platform :ios do
   #    이름이 비슷한 PENDING_APPLE_RELEASE(Apple 이 출시 대기)만 검사하고 있었다.
   #    → guard 를 통과한 뒤 새 버전 생성을 시도해 Apple 이 거부:
   #      "You cannot create a new version of the App in the current state."
+  #    이제 automatic_release: true 라 이 상태는 새로 생기지 않는다. 목록에 남겨둔 건
+  #    전환 이전에 제출됐거나 수동으로 제출한 버전이 걸릴 수 있어서다(안전망).
   #
   # 여기 담는 건 "사람이 코드를 고칠 필요 없이 시간이 지나면 풀리는" 상태뿐이다.
   # REJECTED/INVALID_BINARY 같이 사람 개입이 필요한 상태는 일부러 제외해 빨갛게 실패시킨다.


### PR DESCRIPTION
## 💡 개요

iOS CD 를 `automatic_release: true` 로 전환해, 심사 승인 즉시 자동 출시되도록 합니다.

`false` 였을 때는 승인된 버전이 **개발자 릴리스 대기(PENDING_DEVELOPER_RELEASE)** 로 남고, Apple 은 in-flight 버전이 있으면 새 버전 생성을 거부합니다. 그래서 사람이 App Store Connect 에서 출시 버튼을 누르기 전까지 **다음 배포가 계속 막혔습니다.** 8/2 · 8/5 iOS CD 연속 실패가 이 경로였습니다.

```
deliver/runner.rb:130 verify_version -> app.ensure_version! -> post_app_store_version
[!] You cannot create a new version of the App in the current state.
```

#247 의 guard 추가로 빨간 실패는 막았지만 그건 **스킵(초록불)** 으로 바꾼 것이라, 배포가 안 나가는 근본 원인은 그대로였습니다. 이 PR 이 그 원인을 제거합니다.

## 🔗 관련 이슈

Close #249

## 📃 작업내용

- `fastlane/Fastfile` `release_appstore` 레인: `automatic_release: false` → `true`
- 왜 바꿨는지 / 되돌릴 때 감수해야 할 것(승인마다 수동 출시 필요)을 주석으로 명시
- `blocking_appstore_version` 의 `PENDING_DEVELOPER_RELEASE` 는 **그대로 유지** — 전환 이전에 제출됐거나 수동 제출된 버전이 걸릴 수 있어 안전망으로 남깁니다

## 🔍 테스트 방법

⚠️ 이 경로는 실제 App Store 제출이라 dry-run 으로 검증되지 않습니다. `DRY_RUN=true` 는 `load_asc_api_key` 부터 건너뛰어 스토어 로직을 아예 타지 않고 빌드/서명만 확인합니다.

1. Fastfile 문법 검사 잡 통과 확인 (CI)
2. 머지 후 `Release - iOS App Store` 실행 결과 확인
   - 심사 제출까지 자동으로 진행되는지
   - 승인 이후 App Store Connect 에서 **출시 버튼 없이** 자동 출시되는지

## 🖼️ 스크린샷

## 🙋‍♂️ 질문사항

- 개선할 점, 오타, 코드에 이상한 부분이 있다면 Comment 달아주세요.
- 승인 즉시 자동 출시가 되므로 **출시 시점을 사람이 고를 수 없습니다.** 특정 날짜에 맞춰 내보내야 하는 릴리스가 있다면 이 전환이 맞는지 확인 부탁드립니다.
- 참고: 8/5 당시 iOS 는 pubspec 을 무시하고 ASC 최고 버전 +patch(`1.0.12`) 를 쓰고 있었습니다. #245 로 pubspec 단일 출처(`IOS_VERSION_NAME`)로 바뀌어 다음 실행은 **1.1.4** 를 시도합니다. 8/6 이후 iOS CD 가 한 번도 돌지 않아 이 경로는 아직 미검증입니다.

## ✅ 체크리스트

- [x] 코드가 정상적으로 컴파일되고 실행되는지 확인했습니다.
- [x] 불필요한 코드가 없는지 확인했습니다.
- [x] 코드 스타일 가이드를 준수했습니다.
- [ ] 기존 기능이 정상적으로 작동하는지 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
